### PR TITLE
Load environment variables before import ddtrace

### DIFF
--- a/1-llm-span.ipynb
+++ b/1-llm-span.ipynb
@@ -18,9 +18,11 @@
    "outputs": [],
    "source": [
     "from dotenv import load_dotenv\n",
-    "from ddtrace.llmobs import LLMObs\n",
     "\n",
     "load_dotenv()\n",
+    "\n",
+    "from ddtrace.llmobs import LLMObs\n",
+    "\n",
     "LLMObs.enable()"
    ]
   },


### PR DESCRIPTION
We need to load the env vars before importing ddtrace, this is required for ddtrace to correctly set `config._dd_api_key`