### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ddtrace @ git+https://github.com/DataDog/dd-trace-py.git@main
+ddtrace
 openai==1.30.1
 requests==2.32.2
 urllib3==1.26.15


### PR DESCRIPTION
change 
`ddtrace @ git+https://github.com/DataDog/dd-trace-py.git@main
`
to
`ddtrace
`
In order to avoide error and follow the Datadog docs guide.
`pip install ddtrace
`
https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/python/