### PR TITLE
DOCS-9058 Initial Setup Update

### DIFF
--- a/1-llm-span.ipynb
+++ b/1-llm-span.ipynb
@@ -30,6 +30,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Note for enterprise customers using secrets:**\n",
+    "\n",
+    "If you are using secrets, you can enable LLM Observability with more specific parameters as demonstrated below.\n",
+    "\n",
+    "```python\n",
+    "LLMObs.enable(\n",
+    "  ml_app=\"<YOUR_ML_APP_NAME>\",\n",
+    "  api_key=\"<YOUR_DATADOG_API_KEY>\",\n",
+    "  site=\"<YOUR_DATADOG_SITE>\",\n",
+    "  agentless_enabled=True,\n",
+    ")\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Tracing an LLM Call\n",
     "\n",
     "An LLM Span represents a call to a model. In this simple example, we are asking `gpt-3.5-turbo` to summarize a provided text and identify a list of topics from the text.\n",


### PR DESCRIPTION
Adds a note for enterprise customers using secrets instead of environment variables to set up LLM Observability.

Flagged by Joe in https://datadoghq.atlassian.net/browse/DOCS-9058.