### PR TITLE
Conditional test run logic

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -22,5 +22,5 @@ jobs:
         - uses: actions/setup-python@v5
           with:
             python-version: '3.12'
-        - run: pip install -r requirements.txt
+        - run: pip install -r test/requirements.txt
         - run: pytest

--- a/README.md
+++ b/README.md
@@ -110,4 +110,8 @@ pytest tests/test_sdk.py
 
 # run a specific test
 pytest -k test_sdk_
+
+# run tests for a particular set of libraries
+TEST_LIBS=nodejs pytest ...
+TEST_LIBS=python,nodejs pytest ...
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -10,3 +10,28 @@ libraries, the common functionality is abstracted into language-specific HTTP se
 features as endpoints (see Dockerfiles and server.{py,js,}). An HTTP client is used in test cases to query the
 different servers. Data produced in the servers is routed to a test agent which receives and persists traces and MLObs
 requests to be returned back to the test case.
+
+
+## troubleshooting
+
+### docker objects left running
+
+Sometimes if the test framework fails to exit cleanly then some docker containers may be left running. To clean them up:
+
+```bash
+docker ps  # list any running containers
+docker kill <container_id>
+```
+
+
+```bash
+docker network ls  # list any networks
+
+# rm any networks prefixed with llmobs-test
+docker network rm $(docker network ls --filter name=llmobs-test -q)
+```
+
+
+### `subprocess.CalledProcessError: Command '['/usr/local/bin/docker', 'network', 'rm', 'llmobs-test-...']' returned non-zero exit status 1.`
+
+This likely means that a container wasn't shutdown during the test and so the network cannot be removed.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,31 @@
+import functools
+
+
+def supported(lib, version="", reason=""):
+    def wrapped(func):
+        if not hasattr(func, "library_support"):
+            func.library_support = []
+        func.library_support.append((lib, version, reason))
+
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return inner
+
+    return wrapped
+
+
+def unsupported(lib, reason=""):
+    def wrapped(func):
+        if not hasattr(func, "library_support"):
+            func.library_support = []
+        func.library_support.append((lib, "unsupported", reason))
+
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return inner
+
+    return wrapped

--- a/test/client.py
+++ b/test/client.py
@@ -34,12 +34,14 @@ class InstrumentationClient:
         """Wait for the server to start."""
         for i in range(100):
             try:
-                resp = self._session.get(self._url("/test"))
-                if resp.status_code == 404:
-                    return
+                resp = self._session.get(self._url("/sdk/info"))
+                if 200 <= resp.status_code < 300:
+                    return resp.json()
             except requests.exceptions.RequestException:
                 pass
-            time.sleep(0.1)
+            time.sleep(0.01)
+        else:
+            assert False, "Test server did not start"
 
     def sdk_task(
         self,

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,3 @@
+pytest==8.3.3
+ddapm-test-agent==1.20.0
+requests==2.32.3

--- a/test/server.js
+++ b/test/server.js
@@ -18,6 +18,11 @@ app.use(express.json());
 
 const spans = {};
 
+
+app.get("/sdk/info", (req, res) => {
+    res.json({ version: tracer.version });
+});
+
 app.post('/openai/chat_completion', async (req, res) => {
   const { prompt } = req.body;
   await client.chat.completions.create({

--- a/test/server.js
+++ b/test/server.js
@@ -18,9 +18,9 @@ app.use(express.json());
 
 const spans = {};
 
-
+const tracerVersion = require('dd-trace/package.json').version
 app.get("/sdk/info", (req, res) => {
-    res.json({ version: tracer.version });
+    res.json({ version: tracerVersion });
 });
 
 app.post('/openai/chat_completion', async (req, res) => {

--- a/test/server.py
+++ b/test/server.py
@@ -1,5 +1,6 @@
 import os
 
+import ddtrace
 from ddtrace.llmobs import LLMObs
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -25,6 +26,11 @@ class TaskRequest(BaseModel):
     name: str
     session_id: str
     ml_app: str
+
+
+@app.get("/sdk/info")
+def sdk_version():
+    return {"version": ddtrace.__version__}
 
 
 @app.post("/sdk/task")

--- a/test/test_openai.py
+++ b/test/test_openai.py
@@ -1,3 +1,7 @@
+from . import supported
+
+
+@supported("python", version="1.14.0")
 def test_chat_completion(test_client, test_agent):
     test_client.openai_chat_completion(prompt="Why is Evan Li such a slacker?")
     traces = test_agent.wait_for_num_traces(num=1)

--- a/test/test_openai.py
+++ b/test/test_openai.py
@@ -2,6 +2,7 @@ from . import supported
 
 
 @supported("python", version="1.14.0")
+@supported("nodejs", version="4.4.0")
 def test_chat_completion(test_client, test_agent):
     test_client.openai_chat_completion(prompt="Why is Evan Li such a slacker?")
     traces = test_agent.wait_for_num_traces(num=1)

--- a/test/test_sdk.py
+++ b/test/test_sdk.py
@@ -1,3 +1,7 @@
+from . import unsupported
+
+
+@unsupported("nodejs", reason="nodejs doesn't implement the task method")
 def test_trace_task(test_client, test_agent):
     span = test_client.sdk_task(
         name="test_task", session_id="test_id", ml_app="test_app"


### PR DESCRIPTION
- Run all tests against all libraries by default
- Introduce supported/unsupported decorators for annotating feature support including version requirements.

Tests can be filtered to run against a particular library with a `TEST_LIBS` environment variable.

Some additional troubleshooting docs are added as well.