### PR TITLE
Add ability to assert llmobs requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,37 +81,3 @@ When you're done with the tutorials, deactivate your virtualenv and return to yo
 ```bash
 deactivate
 ```
-
-
-## tests
-
-### installation
-
-```bash
-pip install -r requirements.txt
-```
-
-### format/lint
-
-```bash
-ruff format
-ruff check
-```
-
-
-### running
-
-```bash
-# run all the tests
-pytest
-
-# run all the tests in a file
-pytest tests/test_sdk.py
-
-# run a specific test
-pytest -k test_sdk_
-
-# run tests for a particular set of libraries
-TEST_LIBS=nodejs pytest ...
-TEST_LIBS=python,nodejs pytest ...
-```

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 # tests
 
-This directory contains tests that validate our instrumentation libraries.
+This directory contains tests that validate the LLM Observability instrumentation libraries.
 
 
 ## architecture
@@ -11,6 +11,35 @@ features as endpoints (see Dockerfiles and server.{py,js,}). An HTTP client is u
 different servers. Data produced in the servers is routed to a test agent which receives and persists traces and MLObs
 requests to be returned back to the test case.
 
+## installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## format/lint
+
+```bash
+ruff format
+ruff check
+```
+
+## running
+
+```bash
+# run all the tests
+pytest
+
+# run all the tests in a file
+pytest tests/test_sdk.py
+
+# run a specific test
+pytest -k test_sdk_
+
+# run tests for a particular set of libraries
+TEST_LIBS=nodejs pytest ...
+TEST_LIBS=python,nodejs pytest ...
+```
 
 ## troubleshooting
 

--- a/test/client.py
+++ b/test/client.py
@@ -36,7 +36,7 @@ class InstrumentationClient:
 
     def wait_to_start(self):
         """Wait for the server to start."""
-        for i in range(100):
+        for i in range(1000):
             try:
                 resp = self._session.get(self._url("/sdk/info"))
                 if 200 <= resp.status_code < 300:

--- a/test/client.py
+++ b/test/client.py
@@ -23,12 +23,16 @@ class Span(TypedDict):
 class InstrumentationClient:
     """Client to query the shared interface to the instrumentation libraries."""
 
-    def __init__(self, url: str):
+    def __init__(self, url: str, test_lang: str):
         self._base_url = url
         self._session = requests.Session()
+        self._test_lang = test_lang
 
     def _url(self, path: str) -> str:
         return f"{self._base_url}{path}"
+
+    def __repr__(self):
+        return f"InstrumentationClient(test_lang={self._test_lang!r})"
 
     def wait_to_start(self):
         """Wait for the server to start."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -162,7 +162,9 @@ def test_client(
         volumes=[],
     )
     try:
-        c = client.InstrumentationClient(f"http://0.0.0.0:{local_port}")
+        c = client.InstrumentationClient(
+            f"http://0.0.0.0:{local_port}", test_lang=test_lang
+        )
         server_info = c.wait_to_start()
 
         # Confirm that the test case is compatible with the server

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ from packaging.version import Version
 import shutil
 import socket
 import subprocess
+import time
 import uuid
 
 import pytest
@@ -68,6 +69,16 @@ def testagent_docker_name():
 
 class LLMObsTestAgentClient(TestAgentClient):
     """Extend TestAgentClient to provide additional functionality for LLMObs."""
+
+    def wait_for_llmobs_requests(self, num):
+        """Wait for `num` llmobs requests to be received from the test agent."""
+        num_received = 0
+        while num_received < num:
+            reqs = self.llmobs_requests()
+            num_received = len(reqs)
+            if num_received < num:
+                time.sleep(0.1)
+        return reqs
 
     def llmobs_requests(self):
         reqs = [

--- a/test/server.py
+++ b/test/server.py
@@ -77,4 +77,4 @@ def openai_chat_completion(req: ChatCompletionRequest):
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=os.environ["PORT"])
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ["PORT"]))

--- a/test/test_openai.py
+++ b/test/test_openai.py
@@ -13,5 +13,5 @@ def test_chat_completion(test_lang, test_client, test_agent):
     assert traces[0][0]["name"] == "openai.request"
 
     if test_lang != "nodejs":
-        reqs = test_agent.llmobs_requests()
+        reqs = test_agent.wait_for_llmobs_requests(num=1)
         assert len(reqs) == 1

--- a/test/test_openai.py
+++ b/test/test_openai.py
@@ -15,3 +15,4 @@ def test_chat_completion(test_lang, test_client, test_agent):
     if test_lang != "nodejs":
         reqs = test_agent.wait_for_llmobs_requests(num=1)
         assert len(reqs) == 1
+        assert reqs[0]["event_type"] == "span"

--- a/test/test_openai.py
+++ b/test/test_openai.py
@@ -3,10 +3,15 @@ from . import supported
 
 @supported("python", version="1.14.0")
 @supported("nodejs", version="4.4.0")
-def test_chat_completion(test_client, test_agent):
+def test_chat_completion(test_lang, test_client, test_agent):
     test_client.openai_chat_completion(prompt="Why is Evan Li such a slacker?")
     traces = test_agent.wait_for_num_traces(num=1)
     assert (
         traces[0][0]["meta"]["openai.request.messages.0.content"]
         == "Why is Evan Li such a slacker?"
     ), traces
+    assert traces[0][0]["name"] == "openai.request"
+
+    if test_lang != "nodejs":
+        reqs = test_agent.llmobs_requests()
+        assert len(reqs) == 1


### PR DESCRIPTION
The test agent was extended with support to capture the proxied LLMObs EVP queries in https://github.com/DataDog/dd-apm-test-agent/pull/202. We can leverage this to pull back LLMObs requests and test the data.

[](https://datadoghq.atlassian.net/browse/MLOB-1832)