### PR TITLE
Add back .env gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.env
 .ipynb_checkpoints/
 .venv


### PR DESCRIPTION
This was mistakenly removed in https://github.com/DataDog/llm-observability/pull/13.