### PR TITLE
fix: links to LLM Observability SDK pages

### DIFF
--- a/1-llm-span.ipynb
+++ b/1-llm-span.ipynb
@@ -146,7 +146,7 @@
     "#### Additional resources\n",
     "\n",
     "- [List of all integrations supported by Datadog's LLM Observability product](https://docs.datadoghq.com/tracing/llm_observability/sdk/#llm-integrations)\n",
-    "- [Instructions for manually instrumenting an LLM Span](https://docs.datadoghq.com/tracing/llm_observability/sdk/#llm-span)\n"
+    "- [Instructions for manually instrumenting an LLM Span](https://docs.datadoghq.com/llm_observability/setup/sdk/python/#llm-span)\n"
    ]
   }
  ],

--- a/2-workflow-span.ipynb
+++ b/2-workflow-span.ipynb
@@ -221,7 +221,7 @@
    "outputs": [],
    "source": [
     "# learn more about workflow spans in our docs:\n",
-    "# https://docs.datadoghq.com/tracing/llm_observability/sdk/#workflow-span\n",
+    "# https://docs.datadoghq.com/llm_observability/setup/sdk/python/#workflow-span\n",
     "@workflow()\n",
     "def find_artworks(question):\n",
     "    # We annotate the workflow span with input_data here\n",

--- a/3-agent-span.ipynb
+++ b/3-agent-span.ipynb
@@ -327,7 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# https://docs.datadoghq.com/tracing/llm_observability/sdk/#agent-span\n",
+    "# https://docs.datadoghq.com/llm_observability/setup/sdk/python/#agent-span\n",
     "@agent()\n",
     "def call_weather_assistant(question_prompt):\n",
     "    LLMObs.annotate(\n",


### PR DESCRIPTION
I found a few broken links to documentation as the structure has been changed recently.