### PR TITLE
Add Node.js/TypeScript LLM Experiments SDK

### DIFF
--- a/experiments/node-sdk/.gitignore
+++ b/experiments/node-sdk/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.tgz
+.env
+.DS_Store
+npm-debug.log*

--- a/experiments/node-sdk/README.md
+++ b/experiments/node-sdk/README.md
@@ -1,0 +1,154 @@
+# Datadog LLM Experiments — Node.js / TypeScript SDK
+
+> **Status: preview (v0.1).** The API may change. Not yet published to npm — install from source.
+
+A thin workflow layer over the Datadog LLM Observability API for running LLM
+experiments from Node.js. This SDK is **interface-compatible** with
+[`datadog-llm-experiments-java`](../java-sdk): the same six concepts, the same
+operations, and the same wire format. A user who knows one SDK can use the other
+without learning anything new.
+
+## Requirements
+
+- Node.js 20+ (uses the built-in `fetch` and `node:crypto`)
+- A Datadog API key and Application key
+- [`@datadog/datadog-api-client`](https://github.com/DataDog/datadog-api-client-typescript) `^1.58.0` (the only runtime dependency — installed automatically)
+
+## Install (from source, v0.1)
+
+```bash
+cd experiments/node-sdk
+npm install
+npm run build      # emits dist/
+```
+
+Then depend on it via a local path (`"@datadog/llm-experiments": "file:../node-sdk"`)
+or `npm link`.
+
+## Quick start
+
+```ts
+import { Experiment, ExperimentsClient } from "@datadog/llm-experiments";
+
+const client = new ExperimentsClient({
+  apiKey: process.env.DD_API_KEY!,
+  applicationKey: process.env.DD_APP_KEY!,
+  site: "datadoghq.com",          // optional; defaults to datadoghq.com
+  projectName: "my-project",
+});
+
+const dataset = client
+  .createDataset("greetings", "simple casing dataset")
+  .addRecord("hello", "HELLO", { source: "demo" })
+  .addRecord("world", "WORLD");
+
+const result = await Experiment.builder<string, string>(client)
+  .name("uppercase")
+  .dataset(dataset)
+  .task((input) => input.toUpperCase())
+  .evaluator("matches_expected", (_input, output, expected) => output === expected) // boolean
+  .evaluator("length", (_input, output) => String(output).length)                   // score
+  .tags({ team: "ml-obs" })
+  .build()
+  .run();
+
+console.log(dataset.url());        // https://app.datadoghq.com/llm/datasets/<id>
+console.log(result.url);           // https://app.datadoghq.com/llm/experiments/<id>
+console.log(result.rows.length);
+```
+
+The dataset is created and pushed automatically on the first `run()`. Call
+`await dataset.push()` if you want to push eagerly.
+
+## Concepts
+
+| Type | Purpose |
+|---|---|
+| `ExperimentsClient` | Auth + site + project; factory for datasets and the API escape hatch. |
+| `Dataset` | Record buffer; auto-created and pushed on first experiment run. `dataset.url()` links to its UI page once pushed. |
+| `DatasetRecord` | Immutable `{ input, expectedOutput?, metadata? }`. |
+| `Task<I, O>` | Your callable: `(input, config) => output`. Sync or async. |
+| `Evaluator<V>` | Your callable: `(input, output, expectedOutput) => value`. Sync or async. |
+| `Experiment<I, O>` | Builder + `run()` orchestration. |
+| `ExperimentResult` | What `run()` returns — `rows`, `experimentId`, `url`. |
+
+### Evaluator return types drive the metric type
+
+| Return value | Metric |
+|---|---|
+| `boolean` | boolean metric |
+| `number` | score metric |
+| anything else | categorical metric (stringified) |
+
+### Error handling
+
+- A thrown error (or rejected promise) in a **task** is captured on that row's
+  span (`status: "error"`, `meta.error`); the experiment continues.
+- A thrown error in an **evaluator** is captured as an `error` on that metric;
+  other evaluators and rows continue.
+
+## API parity with the Java SDK
+
+The two SDKs map one-to-one. Node uses object-argument constructors and
+`async/await` where Java uses builders and blocking calls; everything else —
+type names, methods, wire format, auto-tags, metadata propagation — is identical.
+
+| Java | Node |
+|---|---|
+| `ExperimentsClient.builder()....build()` | `new ExperimentsClient({...})` *or* `ExperimentsClient.builder()....build()` |
+| `client.createDataset(name, desc)` | `client.createDataset(name, desc)` |
+| `client.pullDataset(name)` | `await client.pullDataset(name)` |
+| `dataset.addRecord(input, expected, meta)` | `dataset.addRecord(input, expected, meta)` |
+| `Experiment.builder(client)....build()` | `Experiment.builder(client)....build()` |
+| `experiment.run()` | `await experiment.run()` |
+| `result.url()` | `result.url` |
+| `client.api()` (generated `LlmObservabilityApi`) | `client.api()` (generated `LLMObservabilityApi` from `@datadog/datadog-api-client`) |
+
+## Limitations (v0.1)
+
+- **Sequential execution.** Rows run one at a time; parallelism is a v0.2 add.
+- **No tracer dependency.** Spans are emitted via the events endpoint, not
+  `dd-trace`. This is intentional per the polyglot spec.
+- **Transport.** Like the Java SDK, the Node SDK calls the generated
+  `@datadog/datadog-api-client` (`LLMObservabilityApi`) for project, dataset and
+  experiment creation and for the dataset list/record-list reads. The three
+  endpoints with active spec-drift workarounds are hand-rolled over `fetch`,
+  exactly as Java hand-rolls them via `DirectPost`:
+  - **W1** — records POST must send `type: "datasets"` (generated model still emits `"records"`).
+  - **W2** — events POST must send `type: "experiments"` (generated model still emits `"events"`).
+  - experiment **status PATCH** — the generated update model exposes only `name`/`description`, not `status`.
+
+  The SDK also applies **W5** (relaxes the generated deserializer's `required`-field
+  enforcement) and **W6/W7** (a fresh `Configuration` with an explicit
+  `baseServer`, so `DD_SITE` is never read eagerly and every site is allowed).
+- **Staging.** `site: "datad0g.com"` works out of the box (W6/W7).
+
+## Examples
+
+| File | What it shows |
+|---|---|
+| [`examples/topicRelevance.ts`](examples/topicRelevance.ts) | The canonical example: mock task + boolean/numeric/categorical evaluators over 4 records. |
+| [`examples/minimalExperiment.ts`](examples/minimalExperiment.ts) | Smallest end-to-end experiment. |
+| [`examples/datasetOperations.ts`](examples/datasetOperations.ts) | Create + push + pull a dataset by name. |
+
+```bash
+DD_API_KEY=... DD_APPLICATION_KEY=... npm run runTopicRelevance
+```
+
+These are direct ports of the Java SDK examples — same dataset records,
+evaluators, config and tags — so the Node and Java runs produce equivalent
+artifacts. They write to Node-specific projects (`node-sdk-bootstrap`,
+`node-sdk-minimal`; the Java examples use `java-sdk-bootstrap` /
+`java-sdk-minimal`), keeping each SDK's artifacts in its own project for
+side-by-side comparison.
+
+## Develop & test
+
+```bash
+npm test      # unit tests (node:test) — mock fetch, no network
+npm run build # type-check + emit dist/
+```
+
+The unit tests assert the exact wire format (span/metric JSON, `type`
+discriminators, auto-tags, metadata propagation, metric typing, error capture)
+against a mocked `fetch`, so they run offline and pin parity with the spec.

--- a/experiments/node-sdk/README.md
+++ b/experiments/node-sdk/README.md
@@ -3,10 +3,8 @@
 > **Status: preview (v0.1).** The API may change. Not yet published to npm — install from source.
 
 A thin workflow layer over the Datadog LLM Observability API for running LLM
-experiments from Node.js. This SDK is **interface-compatible** with
-[`datadog-llm-experiments-java`](../java-sdk): the same six concepts, the same
-operations, and the same wire format. A user who knows one SDK can use the other
-without learning anything new.
+experiments from Node.js — six small types covering datasets, tasks, evaluators,
+and experiment runs.
 
 ## Requirements
 
@@ -106,33 +104,15 @@ budget, it throws a clear error.
 - A thrown error in an **evaluator** is captured as an `error` on that metric;
   other evaluators and rows continue.
 
-## API parity with the Java SDK
-
-The two SDKs map one-to-one. Node uses object-argument constructors and
-`async/await` where Java uses builders and blocking calls; everything else —
-type names, methods, wire format, auto-tags, metadata propagation — is identical.
-
-| Java | Node |
-|---|---|
-| `ExperimentsClient.builder()....build()` | `new ExperimentsClient({...})` *or* `ExperimentsClient.builder()....build()` |
-| `client.createDataset(name, desc)` | `client.createDataset(name, desc)` |
-| `client.pullDataset(name)` | `await client.pullDataset(name)` (optional `{ expectedRecordCount, maxWaitMs }` — see below) |
-| `dataset.addRecord(input, expected, meta)` | `dataset.addRecord(input, expected, meta)` |
-| `Experiment.builder(client)....build()` | `Experiment.builder(client)....build()` |
-| `experiment.run()` | `await experiment.run()` |
-| `result.url()` | `result.url` |
-| `client.api()` (generated `LlmObservabilityApi`) | `client.api()` (generated `LLMObservabilityApi` from `@datadog/datadog-api-client`) |
-
 ## Limitations (v0.1)
 
 - **Sequential execution.** Rows run one at a time; parallelism is a v0.2 add.
 - **No tracer dependency.** Spans are emitted via the events endpoint, not
-  `dd-trace`. This is intentional per the polyglot spec.
-- **Transport.** Like the Java SDK, the Node SDK calls the generated
-  `@datadog/datadog-api-client` (`LLMObservabilityApi`) for project, dataset and
-  experiment creation and for the dataset list/record-list reads. The three
-  endpoints with active spec-drift workarounds are hand-rolled over `fetch`,
-  exactly as Java hand-rolls them via `DirectPost`:
+  `dd-trace`. This is intentional.
+- **Transport.** The SDK calls the generated `@datadog/datadog-api-client`
+  (`LLMObservabilityApi`) for project, dataset and experiment creation and for
+  the dataset/record list reads. Three endpoints the generated client cannot
+  perform correctly are hand-rolled over `fetch`:
   - **W1** — records POST must send `type: "datasets"` (generated model still emits `"records"`).
   - **W2** — events POST must send `type: "experiments"` (generated model still emits `"events"`).
   - experiment **status PATCH** — the generated update model exposes only `name`/`description`, not `status`.
@@ -154,12 +134,7 @@ type names, methods, wire format, auto-tags, metadata propagation — is identic
 DD_API_KEY=... DD_APPLICATION_KEY=... npm run runTopicRelevance
 ```
 
-These are direct ports of the Java SDK examples — same dataset records,
-evaluators, config and tags — so the Node and Java runs produce equivalent
-artifacts. They write to Node-specific projects (`node-sdk-bootstrap`,
-`node-sdk-minimal`; the Java examples use `java-sdk-bootstrap` /
-`java-sdk-minimal`), keeping each SDK's artifacts in its own project for
-side-by-side comparison.
+The examples write to the `node-sdk-bootstrap` and `node-sdk-minimal` projects.
 
 ## Develop & test
 
@@ -170,4 +145,4 @@ npm run build # type-check + emit dist/
 
 The unit tests assert the exact wire format (span/metric JSON, `type`
 discriminators, auto-tags, metadata propagation, metric typing, error capture)
-against a mocked `fetch`, so they run offline and pin parity with the spec.
+against a mocked `fetch`, so they run offline and pin the wire format.

--- a/experiments/node-sdk/README.md
+++ b/experiments/node-sdk/README.md
@@ -80,6 +80,25 @@ The dataset is created and pushed automatically on the first `run()`. Call
 | `number` | score metric |
 | anything else | categorical metric (stringified) |
 
+### Eventually-consistent reads (`pullDataset`)
+
+LLM Obs reads lag writes slightly, so a `pullDataset` issued right after a push
+can briefly see the dataset missing or only some records. `pullDataset` polls
+with exponential backoff (250ms → 500ms → 1s → …, capped at a 30s total by
+default) until the dataset is visible. Pass `expectedRecordCount` to also wait
+until that many records are readable — confirming the push fully landed — and
+`maxWaitMs` to tune the ceiling:
+
+```ts
+const pulled = await client.pullDataset(name, {
+  expectedRecordCount: dataset.records().length,
+  maxWaitMs: 30_000, // default
+});
+```
+
+If the dataset never appears (or the expected records never arrive) within the
+budget, it throws a clear error.
+
 ### Error handling
 
 - A thrown error (or rejected promise) in a **task** is captured on that row's
@@ -97,7 +116,7 @@ type names, methods, wire format, auto-tags, metadata propagation — is identic
 |---|---|
 | `ExperimentsClient.builder()....build()` | `new ExperimentsClient({...})` *or* `ExperimentsClient.builder()....build()` |
 | `client.createDataset(name, desc)` | `client.createDataset(name, desc)` |
-| `client.pullDataset(name)` | `await client.pullDataset(name)` |
+| `client.pullDataset(name)` | `await client.pullDataset(name)` (optional `{ expectedRecordCount, maxWaitMs }` — see below) |
 | `dataset.addRecord(input, expected, meta)` | `dataset.addRecord(input, expected, meta)` |
 | `Experiment.builder(client)....build()` | `Experiment.builder(client)....build()` |
 | `experiment.run()` | `await experiment.run()` |

--- a/experiments/node-sdk/examples/datasetOperations.ts
+++ b/experiments/node-sdk/examples/datasetOperations.ts
@@ -47,7 +47,11 @@ async function main(): Promise<void> {
   console.log(`Pushed records     : ${dataset.records().length}`);
 
   console.log("=== Pulling the same dataset back from Datadog ===");
-  const pulled = await client.pullDataset(datasetName);
+  // Wait (exponential backoff, up to 30s) until all pushed records are readable —
+  // LLM Obs reads are eventually consistent right after a write.
+  const pulled = await client.pullDataset(datasetName, {
+    expectedRecordCount: dataset.records().length,
+  });
   console.log(`Pulled dataset id  : ${pulled.id()}`);
   console.log(`Pulled records     : ${pulled.records().length}`);
   pulled.records().forEach((rec, i) => {

--- a/experiments/node-sdk/examples/datasetOperations.ts
+++ b/experiments/node-sdk/examples/datasetOperations.ts
@@ -1,0 +1,71 @@
+/**
+ * DatasetOperations — direct port of the Java SDK's `DatasetOperations`.
+ *
+ * Same three records as the Java example; writes to the Node-specific project
+ * `node-sdk-bootstrap` (Java uses `java-sdk-bootstrap`). Creates and pushes a
+ * dataset, then pulls the same dataset back by name and verifies the round-trip.
+ *
+ *   DD_API_KEY=... DD_APPLICATION_KEY=... npm run runDatasetOperations
+ */
+import { ExperimentsClient } from "../src/index.js";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.trim() === "") {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function main(): Promise<void> {
+  const client = new ExperimentsClient({
+    apiKey: requireEnv("DD_API_KEY"),
+    applicationKey: requireEnv("DD_APPLICATION_KEY"),
+    site: process.env.DD_SITE ?? "datadoghq.com",
+    projectName: "node-sdk-bootstrap",
+  });
+
+  const datasetName = `dataset-ops-demo-${Date.now()}`;
+
+  console.log("=== Creating dataset and pushing 3 records ===");
+  const dataset = client
+    .createDataset(datasetName, "Demo of create/push/pull")
+    .addRecord({ question: "What is 2+2?" }, "4", { source: "arithmetic", difficulty: "easy" })
+    .addRecord({ question: "What is the capital of France?" }, "Paris", {
+      source: "geography",
+      difficulty: "medium",
+    })
+    .addRecord(
+      { question: "Define photosynthesis." },
+      "The process by which plants convert light into energy.",
+      { source: "biology", difficulty: "hard" },
+    );
+  await dataset.push();
+  console.log(`Created dataset id : ${dataset.id()}`);
+  console.log(`Dataset URL        : ${dataset.url()}`);
+  console.log(`Pushed records     : ${dataset.records().length}`);
+
+  console.log("=== Pulling the same dataset back from Datadog ===");
+  const pulled = await client.pullDataset(datasetName);
+  console.log(`Pulled dataset id  : ${pulled.id()}`);
+  console.log(`Pulled records     : ${pulled.records().length}`);
+  pulled.records().forEach((rec, i) => {
+    console.log(
+      `  [${i}] input=${JSON.stringify(rec.input)}  expected=${JSON.stringify(rec.expectedOutput)}  metadata=${JSON.stringify(rec.metadata)}`,
+    );
+  });
+
+  if (dataset.id() === pulled.id() && dataset.records().length === pulled.records().length) {
+    console.log("Round-trip OK: created id matches pulled id, record counts match.");
+  } else {
+    console.log(
+      `Mismatch: created.id=${dataset.id()} pulled.id=${pulled.id()} created.count=${dataset.records().length} pulled.count=${pulled.records().length}`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/experiments/node-sdk/examples/datasetOperations.ts
+++ b/experiments/node-sdk/examples/datasetOperations.ts
@@ -1,9 +1,7 @@
 /**
- * DatasetOperations — direct port of the Java SDK's `DatasetOperations`.
- *
- * Same three records as the Java example; writes to the Node-specific project
- * `node-sdk-bootstrap` (Java uses `java-sdk-bootstrap`). Creates and pushes a
- * dataset, then pulls the same dataset back by name and verifies the round-trip.
+ * DatasetOperations — dataset create/push/pull round-trip over three records.
+ * Creates and pushes a dataset, then pulls the same dataset back by name and
+ * verifies the round-trip. Writes to the `node-sdk-bootstrap` project.
  *
  *   DD_API_KEY=... DD_APPLICATION_KEY=... npm run runDatasetOperations
  */

--- a/experiments/node-sdk/examples/minimalExperiment.ts
+++ b/experiments/node-sdk/examples/minimalExperiment.ts
@@ -1,8 +1,6 @@
 /**
- * MinimalExperiment — direct port of the Java SDK's `MinimalExperiment`.
- *
- * Same single record, task and evaluator as the Java example; writes to the
- * Node-specific project `node-sdk-minimal` (Java uses `java-sdk-minimal`).
+ * MinimalExperiment — the smallest end-to-end run: a single record, one task,
+ * one evaluator. Writes to the `node-sdk-minimal` project.
  *
  *   DD_API_KEY=... DD_APPLICATION_KEY=... npm run runMinimalExperiment
  */

--- a/experiments/node-sdk/examples/minimalExperiment.ts
+++ b/experiments/node-sdk/examples/minimalExperiment.ts
@@ -1,0 +1,51 @@
+/**
+ * MinimalExperiment — direct port of the Java SDK's `MinimalExperiment`.
+ *
+ * Same single record, task and evaluator as the Java example; writes to the
+ * Node-specific project `node-sdk-minimal` (Java uses `java-sdk-minimal`).
+ *
+ *   DD_API_KEY=... DD_APPLICATION_KEY=... npm run runMinimalExperiment
+ */
+import { Experiment, ExperimentsClient } from "../src/index.js";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.trim() === "") {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+type Input = { name: string };
+
+async function main(): Promise<void> {
+  const client = new ExperimentsClient({
+    apiKey: requireEnv("DD_API_KEY"),
+    applicationKey: requireEnv("DD_APPLICATION_KEY"),
+    site: process.env.DD_SITE ?? "datadoghq.com",
+    projectName: "node-sdk-minimal",
+  });
+
+  const dataset = client
+    .createDataset(`minimal-${Date.now()}`)
+    .addRecord({ name: "World" }, "Hello, World");
+
+  const result = await Experiment.builder<Input, string>(client)
+    .name("minimal-experiment")
+    .dataset(dataset)
+    .task((input) => `Hello, ${input.name}`)
+    .evaluator("exact_match", (_input, output, expected) => output === expected)
+    .build()
+    .run();
+
+  console.log(`Dataset URL    : ${dataset.url()}`);
+  console.log(`Experiment URL : ${result.url}`);
+  console.log(`Experiment ID  : ${result.experimentId}`);
+  console.log(`Rows           : ${result.rows.length}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/experiments/node-sdk/examples/topicRelevance.ts
+++ b/experiments/node-sdk/examples/topicRelevance.ts
@@ -1,0 +1,122 @@
+/**
+ * TopicRelevance — direct port of the Java SDK's `TopicRelevance` example.
+ *
+ * Identical to the Java example in every respect — same four dataset records
+ * (inputs, expected outputs, metadata), same evaluators, config and tags — except
+ * it writes to the Node-specific project `node-sdk-bootstrap` (the Java example
+ * uses `java-sdk-bootstrap`), so the two SDKs' artifacts stay in separate projects
+ * for easy side-by-side comparison.
+ *
+ *   DD_API_KEY=... DD_APPLICATION_KEY=... [DD_SITE=datadoghq.com] npm run runTopicRelevance
+ */
+import { pathToFileURL } from "node:url";
+import { Dataset, Experiment, ExperimentsClient } from "../src/index.js";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.trim() === "") {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+/**
+ * Mock "task": does the prompt contain any keyword from the (comma-separated)
+ * topics list? Mirrors the Java `keywordOverlap` exactly.
+ */
+function keywordOverlap(prompt: string, topics: string): boolean {
+  const p = prompt.toLowerCase();
+  for (const topic of topics.split(",")) {
+    for (const word of topic.trim().toLowerCase().split(/\s+/)) {
+      if (word !== "" && p.includes(word)) return true;
+    }
+  }
+  return false;
+}
+
+type Input = { prompt: string; topics: string };
+
+/**
+ * Build the dataset + experiment (the part shared by the runnable `main` and the
+ * parity test). `datasetName` is parameterized so tests can use a stable name;
+ * `main` passes a timestamped one, exactly like the Java example.
+ */
+export function buildTopicRelevance(
+  client: ExperimentsClient,
+  datasetName = `topic-relevance-demo-${Date.now()}`,
+): { dataset: Dataset; experiment: Experiment<Input, Record<string, unknown>> } {
+  const dataset = client
+    .createDataset(datasetName, "Java SDK v0.1 smoke test")
+    .addRecord(
+      { prompt: "I love hiking in the mountains on weekends.", topics: "outdoor, travel" },
+      "true",
+      { source: "synthetic", difficulty: "easy" },
+    )
+    .addRecord(
+      { prompt: "Explain quantum entanglement in two sentences.", topics: "outdoor, travel" },
+      "false",
+      { source: "synthetic", difficulty: "easy" },
+    )
+    .addRecord(
+      { prompt: "Best Italian restaurants in Brooklyn?", topics: "food, nyc" },
+      "true",
+      { source: "user-report", difficulty: "medium", reviewer: "alex" },
+    )
+    .addRecord(
+      { prompt: "How do I configure nginx for HTTPS?", topics: "food, nyc" },
+      "false",
+      { source: "user-report", difficulty: "hard", reviewer: "alex" },
+    );
+
+  const experiment = Experiment.builder<Input, Record<string, unknown>>(client)
+    .name("topic-relevance-demo")
+    .dataset(dataset)
+    .task((input) => {
+      const overlap = keywordOverlap(input.prompt, input.topics);
+      return { response: String(overlap), confidence: overlap ? 0.85 : 0.65 };
+    })
+    // boolean: did the predicted response match the expected label?
+    .evaluator("exact_match", (_input, output, expected) => (output as any).response === expected)
+    // score: the model's confidence
+    .evaluator("confidence_score", (_input, output) => Number((output as any).confidence))
+    // categorical: human-readable verdict
+    .evaluator("verdict_category", (_input, output) =>
+      (output as any).response === "true" ? "in-topic" : "off-topic",
+    )
+    .config({ approach: "keyword-overlap", version: "v0.1" })
+    .tags({ variant: "java-v0.1", owner: "design-partner-bootstrap" })
+    .build();
+
+  return { dataset, experiment };
+}
+
+async function main(): Promise<void> {
+  const client = new ExperimentsClient({
+    apiKey: requireEnv("DD_API_KEY"),
+    applicationKey: requireEnv("DD_APPLICATION_KEY"),
+    site: process.env.DD_SITE ?? "datadoghq.com",
+    projectName: "node-sdk-bootstrap",
+  });
+
+  const { dataset, experiment } = buildTopicRelevance(client);
+  const result = await experiment.run();
+
+  console.log(`Dataset URL    : ${dataset.url()}`);
+  console.log(`Experiment URL : ${result.url}`);
+  console.log(`Experiment ID  : ${result.experimentId}`);
+  console.log(`Rows           : ${result.rows.length}`);
+  for (const row of result.rows) {
+    console.log(
+      `  row ${row.index} status=${row.isError ? "error" : "ok"} evals=${JSON.stringify(row.evaluations)}`,
+    );
+  }
+}
+
+// Run only when invoked directly (not when imported by the parity test).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/experiments/node-sdk/examples/topicRelevance.ts
+++ b/experiments/node-sdk/examples/topicRelevance.ts
@@ -1,11 +1,7 @@
 /**
- * TopicRelevance — direct port of the Java SDK's `TopicRelevance` example.
- *
- * Identical to the Java example in every respect — same four dataset records
- * (inputs, expected outputs, metadata), same evaluators, config and tags — except
- * it writes to the Node-specific project `node-sdk-bootstrap` (the Java example
- * uses `java-sdk-bootstrap`), so the two SDKs' artifacts stay in separate projects
- * for easy side-by-side comparison.
+ * TopicRelevance — the canonical example: a mock keyword-overlap task over four
+ * dataset records, scored by a boolean, a numeric, and a categorical evaluator.
+ * Writes to the `node-sdk-bootstrap` project.
  *
  *   DD_API_KEY=... DD_APPLICATION_KEY=... [DD_SITE=datadoghq.com] npm run runTopicRelevance
  */
@@ -23,7 +19,7 @@ function requireEnv(name: string): string {
 
 /**
  * Mock "task": does the prompt contain any keyword from the (comma-separated)
- * topics list? Mirrors the Java `keywordOverlap` exactly.
+ * topics list?
  */
 function keywordOverlap(prompt: string, topics: string): boolean {
   const p = prompt.toLowerCase();
@@ -39,15 +35,15 @@ type Input = { prompt: string; topics: string };
 
 /**
  * Build the dataset + experiment (the part shared by the runnable `main` and the
- * parity test). `datasetName` is parameterized so tests can use a stable name;
- * `main` passes a timestamped one, exactly like the Java example.
+ * artifact test). `datasetName` is parameterized so tests can use a stable name;
+ * `main` passes a timestamped one so each run creates a fresh dataset.
  */
 export function buildTopicRelevance(
   client: ExperimentsClient,
   datasetName = `topic-relevance-demo-${Date.now()}`,
 ): { dataset: Dataset; experiment: Experiment<Input, Record<string, unknown>> } {
   const dataset = client
-    .createDataset(datasetName, "Java SDK v0.1 smoke test")
+    .createDataset(datasetName, "Node SDK v0.1 smoke test")
     .addRecord(
       { prompt: "I love hiking in the mountains on weekends.", topics: "outdoor, travel" },
       "true",
@@ -85,7 +81,7 @@ export function buildTopicRelevance(
       (output as any).response === "true" ? "in-topic" : "off-topic",
     )
     .config({ approach: "keyword-overlap", version: "v0.1" })
-    .tags({ variant: "java-v0.1", owner: "design-partner-bootstrap" })
+    .tags({ variant: "node-v0.1", owner: "design-partner-bootstrap" })
     .build();
 
   return { dataset, experiment };
@@ -113,7 +109,7 @@ async function main(): Promise<void> {
   }
 }
 
-// Run only when invoked directly (not when imported by the parity test).
+// Run only when invoked directly (not when imported by the artifact test).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((err) => {
     console.error(err);

--- a/experiments/node-sdk/package-lock.json
+++ b/experiments/node-sdk/package-lock.json
@@ -1,0 +1,860 @@
+{
+  "name": "@datadog/llm-experiments",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@datadog/llm-experiments",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/datadog-api-client": "^1.58.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@datadog/datadog-api-client": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.58.0.tgz",
+      "integrity": "sha512-aDCMu+qEXjr8PHkT8XvY7FTzVNi2z7yVJy39I4s0lVtb+sdth4ZppMC1aCDwGJQMHK4J0aect+xKScuHy/Xilg==",
+      "dependencies": {
+        "@types/buffer-from": "^1.1.0",
+        "@types/node": "*",
+        "@types/pako": "^1.0.3",
+        "buffer-from": "^1.1.2",
+        "cross-fetch": "^3.1.5",
+        "form-data": "^4.0.4",
+        "loglevel": "^1.8.1",
+        "pako": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/buffer-from": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/buffer-from/-/buffer-from-1.1.3.tgz",
+      "integrity": "sha512-2lq4YC9uLUMGHkl2IDtX4tCXSo2+hwMpOJcY1qiIk1kybc31rIlPyM1HCVJhkPFIo75a/pOVxqyvwuf5TpCG/w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pako": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.7.tgz",
+      "integrity": "sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/experiments/node-sdk/package.json
+++ b/experiments/node-sdk/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@datadog/llm-experiments",
+  "version": "0.1.0",
+  "description": "Thin workflow layer over the Datadog LLM Observability API for running LLM experiments (Node.js / TypeScript). Interface parity with datadog-llm-experiments-java.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@datadog/datadog-api-client": "^1.58.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "prepack": "npm run clean && npm run build",
+    "test": "node --import tsx --test test/*.test.ts",
+    "sanity": "node --import tsx sanity-check.ts",
+    "runTopicRelevance": "node --import tsx examples/topicRelevance.ts",
+    "runMinimalExperiment": "node --import tsx examples/minimalExperiment.ts",
+    "runDatasetOperations": "node --import tsx examples/datasetOperations.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/experiments/node-sdk/sanity-check.ts
+++ b/experiments/node-sdk/sanity-check.ts
@@ -1,0 +1,163 @@
+/**
+ * Offline sanity check for the LLM Experiments Node SDK.
+ *
+ * Exercises the entire library end-to-end — client → dataset → experiment →
+ * run() → result — against an in-process mock transport. No API keys and no
+ * network required: it verifies the library *wiring* (generated-client calls,
+ * hand-rolled W1/W2/status calls, span/metric wire format, evaluator typing,
+ * error capture). Exits non-zero if any assertion fails.
+ *
+ *   npm run sanity
+ *   # or: node --import tsx sanity-check.ts
+ *
+ * For a *live* check against a real Datadog org, use the examples instead
+ * (npm run example:minimal), which need DD_API_KEY / DD_APP_KEY.
+ */
+import { client } from "@datadog/datadog-api-client";
+import { Experiment, ExperimentsClient } from "./src/index.js";
+
+// ---------------------------------------------------------------------------
+// Tiny mock transport: serves both the generated client (via HttpLibrary) and
+// the hand-rolled fetch calls (via globalThis.fetch). Records every request.
+// ---------------------------------------------------------------------------
+const requests: Array<{ method: string; path: string; via: string; body: any }> = [];
+
+function respond(method: string, path: string, body: any): { status: number; payload: unknown } {
+  const recordsPath = "/api/v2/llm-obs/v1/proj/datasets/ds/records";
+  if (method === "POST" && path === "/api/v2/llm-obs/v1/projects") {
+    return { status: 200, payload: { data: { id: "proj", type: "projects", attributes: { name: "p" } } } };
+  }
+  if (method === "POST" && path === recordsPath) {
+    const sent: unknown[] = body?.data?.attributes?.records ?? [];
+    return { status: 200, payload: { data: sent.map((_, i) => ({ id: `rec-${i}` })) } };
+  }
+  if (method === "POST" && path === "/api/v2/llm-obs/v1/proj/datasets") {
+    return { status: 200, payload: { data: { id: "ds", type: "datasets", attributes: { name: "d" } } } };
+  }
+  if (method === "POST" && path === "/api/v2/llm-obs/v1/experiments") {
+    return { status: 200, payload: { data: { id: "exp", type: "experiments", attributes: { name: "e" } } } };
+  }
+  if (method === "POST" && path.endsWith("/events")) return { status: 202, payload: {} };
+  if (method === "PATCH" && path.startsWith("/api/v2/llm-obs/v1/experiments/")) return { status: 200, payload: { data: { id: "exp" } } };
+  return { status: 404, payload: { error: `no route for ${method} ${path}` } };
+}
+
+// transport 1: hand-rolled fetch (records POST, events POST, status PATCH)
+globalThis.fetch = (async (input: string, init?: RequestInit) => {
+  const path = new URL(String(input)).pathname;
+  const method = (init?.method ?? "GET").toUpperCase();
+  const body = init?.body ? JSON.parse(init.body as string) : undefined;
+  requests.push({ method, path, via: "fetch", body });
+  const { status, payload } = respond(method, path, body);
+  return new Response(JSON.stringify(payload), { status });
+}) as unknown as typeof globalThis.fetch;
+
+// transport 2: generated client (project/dataset/experiment create + lists)
+const httpApi: client.HttpLibrary = {
+  send: async (req: client.RequestContext): Promise<client.ResponseContext> => {
+    const path = new URL(req.getUrl()).pathname;
+    const method = String(req.getHttpMethod()).toUpperCase();
+    const raw = req.getBody();
+    const body = typeof raw === "string" && raw ? JSON.parse(raw) : undefined;
+    requests.push({ method, path, via: "generated", body });
+    const { status, payload } = respond(method, path, body);
+    const json = JSON.stringify(payload);
+    return new client.ResponseContext(status, {}, { text: async () => json, binary: async () => Buffer.from(json) });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// The actual sanity run.
+// ---------------------------------------------------------------------------
+let failures = 0;
+function check(label: string, cond: boolean, detail = ""): void {
+  const mark = cond ? "✓" : "✗";
+  if (!cond) failures++;
+  console.log(`  ${mark} ${label}${detail ? ` — ${detail}` : ""}`);
+}
+
+async function main(): Promise<void> {
+  console.log("LLM Experiments Node SDK — offline sanity check\n");
+
+  const cdClient = new ExperimentsClient({
+    apiKey: "fake-key",
+    applicationKey: "fake-app-key",
+    site: "datad0g.com", // staging — exercises the W6/W7 server config
+    projectName: "sanity-project",
+    httpApi, // inject mock transport
+  });
+
+  console.log("1. Build dataset");
+  const dataset = cdClient
+    .createDataset("sanity-dataset", "a tiny dataset")
+    .addRecord("apple banana", "fruit", { row: 0 })
+    .addRecord("car truck", "vehicle", { row: 1 })
+    .addRecord("BOOM", "n/a", { row: 2 }); // this row's task will throw
+  check("dataset starts unpushed", dataset.id() === null);
+  check("3 records buffered", dataset.records().length === 3);
+
+  console.log("\n2. Build + run experiment");
+  const experiment = Experiment.builder<string, string>(cdClient)
+    .name("sanity-experiment")
+    .description("offline sanity")
+    .dataset(dataset)
+    .task((input) => {
+      if (input === "BOOM") throw new Error("intentional task failure");
+      return `echo:${input}`;
+    })
+    .evaluator("nonempty", (_i, o) => typeof o === "string" && o.length > 0) // boolean
+    .evaluator("length", (_i, o) => String(o ?? "").length) // number → score
+    .evaluator("verdict", (_i, o) => (String(o).includes("apple") ? "match" : "miss")) // categorical
+    .tags({ env: "sanity" })
+    .config({ temperature: 0 })
+    .build();
+
+  const result = await experiment.run();
+
+  console.log("\n3. Result");
+  console.log(`   experimentId: ${result.experimentId}`);
+  console.log(`   url:          ${result.url}`);
+  console.log(`   rows:         ${result.rows.length}`);
+  check("experiment id resolved", result.experimentId === "exp");
+  check("staging experiment url", result.url === "https://app.datad0g.com/llm/experiments/exp");
+  check("dataset links to its dashboard page", dataset.url() === "https://app.datad0g.com/llm/datasets/ds");
+  check("one row per record", result.rows.length === 3);
+  check("row 0 output", result.rows[0].output === "echo:apple banana");
+  check("row 0 boolean eval", result.rows[0].evaluations.nonempty === true);
+  check("row 0 score eval", result.rows[0].evaluations.length === "echo:apple banana".length);
+  check("row 0 categorical eval", result.rows[0].evaluations.verdict === "match");
+  check("row 2 captured task error", result.rows[2].isError && result.rows[2].errorMessage === "intentional task failure");
+
+  console.log("\n4. Transport split (parity with Java)");
+  const generated = requests.filter((r) => r.via === "generated").map((r) => `${r.method} ${r.path}`);
+  const handRolled = requests.filter((r) => r.via === "fetch").map((r) => `${r.method} ${r.path}`);
+  console.log("   via generated client:");
+  for (const r of generated) console.log(`     - ${r}`);
+  console.log("   hand-rolled over fetch:");
+  for (const r of handRolled) console.log(`     - ${r}`);
+  check("project/dataset/experiment created via generated client", generated.length === 3);
+  check("records + events + status hand-rolled", handRolled.length === 3);
+
+  console.log("\n5. Wire-format spot checks");
+  const recordsReq = requests.find((r) => r.path.endsWith("/records"));
+  const eventsReq = requests.find((r) => r.path.endsWith("/events"));
+  check("W1: records POST sends type 'datasets'", recordsReq?.body?.data?.type === "datasets");
+  check("W2: events POST sends type 'experiments'", eventsReq?.body?.data?.type === "experiments");
+  const span0 = eventsReq?.body?.data?.attributes?.spans?.[0];
+  check("span has 32-hex span_id", /^[0-9a-f]{32}$/.test(span0?.span_id ?? ""));
+  check("span carries auto experiment_id tag", (span0?.tags ?? []).includes("experiment_id:exp"));
+  check("span metadata is raw/unwrapped", JSON.stringify(span0?.meta?.metadata) === JSON.stringify({ row: 0 }));
+  const metrics = eventsReq?.body?.data?.attributes?.metrics ?? [];
+  check("metrics emitted (3 evaluators × 3 rows)", metrics.length === 9);
+  check("boolean metric typed", metrics.some((m: any) => m.metric_type === "boolean" && m.boolean_value === true));
+  check("score metric typed", metrics.some((m: any) => m.metric_type === "score" && typeof m.score_value === "number"));
+  check("categorical metric typed", metrics.some((m: any) => m.metric_type === "categorical" && m.categorical_value === "match"));
+
+  console.log(`\n${failures === 0 ? "✅ All sanity checks passed." : `❌ ${failures} sanity check(s) failed.`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("\n❌ Sanity check crashed:", err);
+  process.exit(1);
+});

--- a/experiments/node-sdk/sanity-check.ts
+++ b/experiments/node-sdk/sanity-check.ts
@@ -128,7 +128,7 @@ async function main(): Promise<void> {
   check("row 0 categorical eval", result.rows[0].evaluations.verdict === "match");
   check("row 2 captured task error", result.rows[2].isError && result.rows[2].errorMessage === "intentional task failure");
 
-  console.log("\n4. Transport split (parity with Java)");
+  console.log("\n4. Transport split (generated client vs hand-rolled)");
   const generated = requests.filter((r) => r.via === "generated").map((r) => `${r.method} ${r.path}`);
   const handRolled = requests.filter((r) => r.via === "fetch").map((r) => `${r.method} ${r.path}`);
   console.log("   via generated client:");

--- a/experiments/node-sdk/src/Dataset.ts
+++ b/experiments/node-sdk/src/Dataset.ts
@@ -1,0 +1,181 @@
+import { DatasetRecord } from "./DatasetRecord.js";
+import type { ExperimentsClient } from "./ExperimentsClient.js";
+import * as http from "./internal/http.js";
+import { appBase } from "./internal/http.js";
+
+/**
+ * A local buffer of dataset records, auto-created and pushed remotely on the
+ * first `experiment.run()` (or eagerly via `push()`). Mirrors the Java `Dataset`.
+ *
+ * `addRecord` is fluent. `id()`/`projectId()` are null until the dataset has been
+ * pushed.
+ */
+export class Dataset {
+  private readonly client: ExperimentsClient;
+  private readonly _name: string;
+  private readonly _description: string;
+  private readonly _records: DatasetRecord[] = [];
+  private readonly _recordIds: string[] = [];
+  private _id: string | null = null;
+  private _projectId: string | null = null;
+  private pushedCount = 0;
+
+  constructor(client: ExperimentsClient, name: string, description = "") {
+    this.client = client;
+    this._name = name;
+    this._description = description;
+  }
+
+  /** @internal — build a Dataset that already exists remotely (used by pullDataset). */
+  static fromExisting(
+    client: ExperimentsClient,
+    name: string,
+    description: string,
+    id: string,
+    projectId: string,
+    records: DatasetRecord[],
+    recordIds: string[],
+  ): Dataset {
+    const ds = new Dataset(client, name, description);
+    ds._id = id;
+    ds._projectId = projectId;
+    ds._records.push(...records);
+    ds._recordIds.push(...recordIds);
+    ds.pushedCount = records.length;
+    return ds;
+  }
+
+  /** Append a record. Accepts either a DatasetRecord or `(input, expectedOutput?, metadata?)`. */
+  addRecord(record: DatasetRecord): Dataset;
+  addRecord(
+    input: unknown,
+    expectedOutput?: unknown,
+    metadata?: Record<string, unknown>,
+  ): Dataset;
+  addRecord(
+    recordOrInput: DatasetRecord | unknown,
+    expectedOutput?: unknown,
+    metadata?: Record<string, unknown>,
+  ): Dataset {
+    const record =
+      recordOrInput instanceof DatasetRecord
+        ? recordOrInput
+        : new DatasetRecord(recordOrInput, expectedOutput, metadata);
+    this._records.push(record);
+    return this;
+  }
+
+  name(): string {
+    return this._name;
+  }
+
+  records(): readonly DatasetRecord[] {
+    return [...this._records];
+  }
+
+  /** @internal — record ids aligned by index with `records()` (after push). */
+  recordIds(): readonly string[] {
+    return [...this._recordIds];
+  }
+
+  /** Dataset id, or null until pushed. */
+  id(): string | null {
+    return this._id;
+  }
+
+  /** Project id, or null until pushed. */
+  projectId(): string | null {
+    return this._projectId;
+  }
+
+  /** Dashboard URL for this dataset, or null until it has been pushed/pulled. */
+  url(): string | null {
+    if (this._id === null) return null;
+    return `${appBase(this.client.site())}/llm/datasets/${this._id}`;
+  }
+
+  /** Eagerly create the dataset (if needed) and push any unpushed records. */
+  async push(): Promise<void> {
+    const projectId = await this.client.ensureProjectId();
+    await this.ensureCreatedAndPushed(projectId);
+  }
+
+  /**
+   * @internal — create the remote dataset if it does not yet exist, then push any
+   * records added since the last push. Idempotent and incremental: tracks
+   * `pushedCount` so repeated calls only send new records.
+   */
+  async ensureCreatedAndPushed(projectId: string): Promise<void> {
+    const creds = this.client.credentials();
+
+    if (this._id === null) {
+      // Dataset creation goes through the generated client (no active workaround).
+      try {
+        const resp = await this.client.api().createLLMObsDataset({
+          projectId,
+          body: {
+            data: {
+              type: "datasets",
+              attributes: { name: this._name, description: this._description },
+            },
+          },
+        });
+        this._id = String(resp?.data?.id ?? "");
+        this._projectId = projectId;
+      } catch (err) {
+        throw new Error(`Failed to create dataset '${this._name}': ${(err as Error).message}`);
+      }
+    }
+
+    if (this.pushedCount >= this._records.length) {
+      return;
+    }
+
+    const pending = this._records.slice(this.pushedCount);
+    const recordPayload = pending.map((rec) => {
+      const r: Record<string, unknown> = { input: rec.input };
+      if (rec.expectedOutput !== null && rec.expectedOutput !== undefined) {
+        r.expected_output = rec.expectedOutput;
+      }
+      if (rec.metadata && Object.keys(rec.metadata).length > 0) {
+        r.metadata = rec.metadata;
+      }
+      return r;
+    });
+
+    // W1: the records POST must send type "datasets"; the generated client's
+    // model still serializes "records", which the API rejects. Hand-roll it.
+    const body = {
+      data: {
+        type: "datasets",
+        attributes: { records: recordPayload },
+      },
+    };
+
+    let raw: string;
+    try {
+      raw = await http.postReturning(
+        creds,
+        `/api/v2/llm-obs/v1/${projectId}/datasets/${this._id}/records`,
+        body,
+      );
+    } catch (err) {
+      throw new Error(`Failed to push records to dataset '${this._name}': ${(err as Error).message}`);
+    }
+
+    // Capture returned record ids in order; pad with "" if the response omits them.
+    const parsed = JSON.parse(raw);
+    const data = parsed?.data;
+    if (Array.isArray(data)) {
+      for (const node of data) {
+        this._recordIds.push(String((node as Record<string, any>)?.id ?? ""));
+      }
+    } else {
+      for (let i = 0; i < pending.length; i++) {
+        this._recordIds.push("");
+      }
+    }
+
+    this.pushedCount = this._records.length;
+  }
+}

--- a/experiments/node-sdk/src/Dataset.ts
+++ b/experiments/node-sdk/src/Dataset.ts
@@ -5,7 +5,7 @@ import { appBase } from "./internal/http.js";
 
 /**
  * A local buffer of dataset records, auto-created and pushed remotely on the
- * first `experiment.run()` (or eagerly via `push()`). Mirrors the Java `Dataset`.
+ * first `experiment.run()` (or eagerly via `push()`).
  *
  * `addRecord` is fluent. `id()`/`projectId()` are null until the dataset has been
  * pushed.

--- a/experiments/node-sdk/src/DatasetRecord.ts
+++ b/experiments/node-sdk/src/DatasetRecord.ts
@@ -1,0 +1,21 @@
+/**
+ * Immutable dataset record: `{ input, expectedOutput?, metadata? }`.
+ *
+ * Mirrors the Java `DatasetRecord`. `metadata` is propagated raw (unwrapped) to
+ * the experiment span's `meta.metadata`.
+ */
+export class DatasetRecord {
+  readonly input: unknown;
+  readonly expectedOutput: unknown;
+  readonly metadata: Record<string, unknown>;
+
+  constructor(
+    input: unknown,
+    expectedOutput?: unknown,
+    metadata?: Record<string, unknown>,
+  ) {
+    this.input = input;
+    this.expectedOutput = expectedOutput ?? null;
+    this.metadata = metadata ?? {};
+  }
+}

--- a/experiments/node-sdk/src/DatasetRecord.ts
+++ b/experiments/node-sdk/src/DatasetRecord.ts
@@ -1,8 +1,8 @@
 /**
  * Immutable dataset record: `{ input, expectedOutput?, metadata? }`.
  *
- * Mirrors the Java `DatasetRecord`. `metadata` is propagated raw (unwrapped) to
- * the experiment span's `meta.metadata`.
+ * `metadata` is propagated raw (unwrapped) to the experiment span's
+ * `meta.metadata`.
  */
 export class DatasetRecord {
   readonly input: unknown;

--- a/experiments/node-sdk/src/Evaluator.ts
+++ b/experiments/node-sdk/src/Evaluator.ts
@@ -1,8 +1,7 @@
 /**
  * User-provided evaluator: `(input, output, expectedOutput) -> value`.
  *
- * Equivalent to the Java `Evaluator<V>` functional interface. May be sync or
- * async. The return type drives the metric type (see MetricBuilder):
+ * May be sync or async. The return type drives the metric type (see MetricBuilder):
  *   - boolean -> boolean metric
  *   - number  -> score metric
  *   - anything else -> categorical metric (stringified)

--- a/experiments/node-sdk/src/Evaluator.ts
+++ b/experiments/node-sdk/src/Evaluator.ts
@@ -1,0 +1,17 @@
+/**
+ * User-provided evaluator: `(input, output, expectedOutput) -> value`.
+ *
+ * Equivalent to the Java `Evaluator<V>` functional interface. May be sync or
+ * async. The return type drives the metric type (see MetricBuilder):
+ *   - boolean -> boolean metric
+ *   - number  -> score metric
+ *   - anything else -> categorical metric (stringified)
+ *
+ * A thrown error / rejected promise is captured per-evaluation as an `error` on
+ * the metric; the experiment continues.
+ */
+export type Evaluator<V = unknown> = (
+  input: unknown,
+  output: unknown,
+  expectedOutput: unknown,
+) => V | Promise<V>;

--- a/experiments/node-sdk/src/Experiment.ts
+++ b/experiments/node-sdk/src/Experiment.ts
@@ -1,0 +1,309 @@
+import type { Dataset } from "./Dataset.js";
+import type { Evaluator } from "./Evaluator.js";
+import { ExperimentResult, Row } from "./ExperimentResult.js";
+import type { ExperimentsClient } from "./ExperimentsClient.js";
+import type { Task } from "./Task.js";
+import * as http from "./internal/http.js";
+import { appBase } from "./internal/http.js";
+import { hexId } from "./internal/ids.js";
+import { toMetric } from "./internal/metricBuilder.js";
+import { toSpan } from "./internal/spanBuilder.js";
+
+/**
+ * Builder + `run()` orchestration. Mirrors the Java `Experiment<I, O>`.
+ *
+ * v0.1 runs sequentially (one row at a time), emits one root span per dataset
+ * row, and posts all spans + metrics in a single events call.
+ */
+export class Experiment<I = unknown, O = unknown> {
+  private readonly client: ExperimentsClient;
+  private readonly _name: string;
+  private readonly _description: string;
+  private readonly dataset: Dataset;
+  private readonly task: Task<I, O>;
+  private readonly evaluators: Map<string, Evaluator>;
+  private readonly config: Record<string, unknown>;
+  private readonly tags: Record<string, string>;
+  private _experimentId: string | null = null;
+
+  private constructor(b: ExperimentBuilder<I, O>) {
+    if (!b._name) throw new Error("Experiment name is required");
+    if (!b._dataset) throw new Error("Experiment dataset is required");
+    if (!b._task) throw new Error("Experiment task is required");
+    this.client = b.client;
+    this._name = b._name;
+    this._description = b._description;
+    this.dataset = b._dataset;
+    this.task = b._task;
+    this.evaluators = new Map(b._evaluators);
+    this.config = { ...b._config };
+    this.tags = { ...b._tags };
+  }
+
+  static builder<I = unknown, O = unknown>(client: ExperimentsClient): ExperimentBuilder<I, O> {
+    return new ExperimentBuilder<I, O>(client);
+  }
+
+  /** @internal — bridge so ExperimentBuilder.build() can reach the private ctor. */
+  static fromBuilder<I, O>(b: ExperimentBuilder<I, O>): Experiment<I, O> {
+    return new Experiment<I, O>(b);
+  }
+
+  name(): string {
+    return this._name;
+  }
+
+  experimentId(): string | null {
+    return this._experimentId;
+  }
+
+  /** Dashboard URL for the experiment. Null until `run()` has created it. */
+  url(): string | null {
+    if (this._experimentId === null) return null;
+    return `${appBase(this.client.site())}/llm/experiments/${this._experimentId}`;
+  }
+
+  /** Run the experiment sequentially and return the result. */
+  async run(): Promise<ExperimentResult> {
+    const projectId = await this.client.ensureProjectId();
+
+    // Ensure the dataset exists remotely and all records are pushed.
+    await this.dataset.ensureCreatedAndPushed(projectId);
+    const datasetId = this.dataset.id();
+    if (datasetId === null) {
+      throw new Error(`Dataset '${this.dataset.name()}' has no id after push`);
+    }
+
+    // Create the experiment through the generated client. ensureUnique:true makes
+    // the backend mint a fresh experiment under the project on every run.
+    try {
+      const resp = await this.client.api().createLLMObsExperiment({
+        body: {
+          data: {
+            type: "experiments",
+            attributes: {
+              name: this._name,
+              projectId,
+              datasetId,
+              description: this._description,
+              ...(Object.keys(this.config).length > 0 ? { config: this.config } : {}),
+              ensureUnique: true,
+            },
+          },
+        },
+      });
+      this._experimentId = String(resp?.data?.id ?? "");
+    } catch (err) {
+      throw new Error(`Failed to create experiment '${this._name}': ${(err as Error).message}`);
+    }
+    const experimentId = this._experimentId as string;
+
+    // Best-effort interrupt handling: if the process is signalled mid-run, mark
+    // the experiment interrupted (mirrors the Java shutdown hook).
+    let finished = false;
+    const interruptHandler = () => {
+      if (!finished) {
+        void this.updateStatus("interrupted", "Process terminated before run completed");
+      }
+    };
+    process.once("SIGINT", interruptHandler);
+    process.once("SIGTERM", interruptHandler);
+
+    try {
+      const records = this.dataset.records();
+      const recordIds = this.dataset.recordIds();
+      const rows: Row[] = [];
+      const spans: Record<string, unknown>[] = [];
+      const metrics: Record<string, unknown>[] = [];
+
+      for (let i = 0; i < records.length; i++) {
+        const record = records[i];
+        const datasetRecordId = i < recordIds.length ? recordIds[i] : "";
+        const spanId = hexId();
+        const traceId = hexId();
+        const startMs = Date.now();
+        const startNs = startMs * 1_000_000;
+        const startHr = process.hrtime.bigint();
+
+        let output: unknown = null;
+        let errorType: string | null = null;
+        let errorMessage: string | null = null;
+
+        try {
+          output = await this.task(record.input as I, this.config);
+        } catch (err) {
+          const e = err as Error;
+          errorType = e.name || "Error";
+          errorMessage = e.message ?? String(err);
+        }
+
+        const durationNs = Number(process.hrtime.bigint() - startHr);
+
+        // Run evaluators (only when the task itself did not error).
+        const evaluations: Record<string, unknown> = {};
+        const evaluationErrors: Record<string, string> = {};
+        const timestampMs = Date.now();
+
+        for (const [label, evaluator] of this.evaluators) {
+          if (errorType !== null) {
+            // Task failed — record an evaluation error so the metric reflects it.
+            const msg = "task error; evaluation skipped";
+            evaluationErrors[label] = msg;
+            metrics.push(
+              toMetric(label, null, msg, spanId, timestampMs, experimentId, this.tags),
+            );
+            continue;
+          }
+          try {
+            const value = await evaluator(record.input, output, record.expectedOutput);
+            evaluations[label] = value;
+            metrics.push(
+              toMetric(label, value, null, spanId, timestampMs, experimentId, this.tags),
+            );
+          } catch (err) {
+            const msg = (err as Error).message ?? String(err);
+            evaluationErrors[label] = msg;
+            metrics.push(
+              toMetric(label, null, msg, spanId, timestampMs, experimentId, this.tags),
+            );
+          }
+        }
+
+        const row = new Row({
+          index: i,
+          spanId,
+          traceId,
+          startNs,
+          durationNs,
+          input: record.input,
+          output,
+          expectedOutput: record.expectedOutput,
+          errorType,
+          errorMessage,
+          evaluations,
+          evaluationErrors,
+        });
+        rows.push(row);
+        spans.push(
+          toSpan(
+            row,
+            record.metadata,
+            experimentId,
+            projectId,
+            datasetId,
+            datasetRecordId,
+            this._name,
+            this.tags,
+          ),
+        );
+      }
+
+      // Post all spans + metrics in a single events call.
+      await this.postEvents(experimentId, spans, metrics);
+      await this.updateStatus("completed", null);
+      finished = true;
+
+      return new ExperimentResult(experimentId, rows, this.url() as string);
+    } catch (err) {
+      await this.updateStatus("failed", (err as Error).message ?? String(err));
+      finished = true;
+      throw err;
+    } finally {
+      process.removeListener("SIGINT", interruptHandler);
+      process.removeListener("SIGTERM", interruptHandler);
+    }
+  }
+
+  private async postEvents(
+    experimentId: string,
+    spans: Record<string, unknown>[],
+    metrics: Record<string, unknown>[],
+  ): Promise<void> {
+    // W2: the events POST uses type "experiments" (not "events").
+    const body = {
+      data: {
+        type: "experiments",
+        attributes: { spans, metrics },
+      },
+    };
+    await http.post(
+      this.client.credentials(),
+      `/api/v2/llm-obs/v1/experiments/${experimentId}/events`,
+      body,
+    );
+  }
+
+  private async updateStatus(status: string, error: string | null): Promise<void> {
+    // Hand-rolled: the generated updateLLMObsExperiment model exposes only
+    // name/description, not `status`/`error`, so the lifecycle PATCH bypasses it
+    // (same approach as the Java SDK).
+    if (this._experimentId === null) return;
+    const attributes: Record<string, unknown> = { status };
+    if (error !== null) attributes.error = error;
+    try {
+      await http.patch(
+        this.client.credentials(),
+        `/api/v2/llm-obs/v1/experiments/${this._experimentId}`,
+        { data: { type: "experiments", attributes } },
+      );
+    } catch {
+      // Status update is best-effort; never let it mask the real result/error.
+    }
+  }
+}
+
+/** Builder mirroring the Java `Experiment.Builder<I, O>`. */
+export class ExperimentBuilder<I = unknown, O = unknown> {
+  /** @internal */ readonly client: ExperimentsClient;
+  /** @internal */ _name = "";
+  /** @internal */ _description = "";
+  /** @internal */ _dataset: Dataset | null = null;
+  /** @internal */ _task: Task<I, O> | null = null;
+  /** @internal */ _evaluators = new Map<string, Evaluator>();
+  /** @internal */ _config: Record<string, unknown> = {};
+  /** @internal */ _tags: Record<string, string> = {};
+
+  constructor(client: ExperimentsClient) {
+    this.client = client;
+  }
+
+  name(name: string): this {
+    this._name = name;
+    return this;
+  }
+
+  description(description: string): this {
+    this._description = description;
+    return this;
+  }
+
+  dataset(dataset: Dataset): this {
+    this._dataset = dataset;
+    return this;
+  }
+
+  task(task: Task<I, O>): this {
+    this._task = task;
+    return this;
+  }
+
+  /** Register an evaluator under a label. Multiple calls allowed. */
+  evaluator(label: string, evaluator: Evaluator): this {
+    this._evaluators.set(label, evaluator);
+    return this;
+  }
+
+  config(config: Record<string, unknown>): this {
+    this._config = { ...config };
+    return this;
+  }
+
+  tags(tags: Record<string, string>): this {
+    this._tags = { ...tags };
+    return this;
+  }
+
+  build(): Experiment<I, O> {
+    return Experiment.fromBuilder<I, O>(this);
+  }
+}

--- a/experiments/node-sdk/src/Experiment.ts
+++ b/experiments/node-sdk/src/Experiment.ts
@@ -10,7 +10,7 @@ import { toMetric } from "./internal/metricBuilder.js";
 import { toSpan } from "./internal/spanBuilder.js";
 
 /**
- * Builder + `run()` orchestration. Mirrors the Java `Experiment<I, O>`.
+ * Builder + `run()` orchestration.
  *
  * v0.1 runs sequentially (one row at a time), emits one root span per dataset
  * row, and posts all spans + metrics in a single events call.
@@ -99,7 +99,7 @@ export class Experiment<I = unknown, O = unknown> {
     const experimentId = this._experimentId as string;
 
     // Best-effort interrupt handling: if the process is signalled mid-run, mark
-    // the experiment interrupted (mirrors the Java shutdown hook).
+    // the experiment interrupted.
     let finished = false;
     const interruptHandler = () => {
       if (!finished) {
@@ -235,8 +235,7 @@ export class Experiment<I = unknown, O = unknown> {
 
   private async updateStatus(status: string, error: string | null): Promise<void> {
     // Hand-rolled: the generated updateLLMObsExperiment model exposes only
-    // name/description, not `status`/`error`, so the lifecycle PATCH bypasses it
-    // (same approach as the Java SDK).
+    // name/description, not `status`/`error`, so the lifecycle PATCH bypasses it.
     if (this._experimentId === null) return;
     const attributes: Record<string, unknown> = { status };
     if (error !== null) attributes.error = error;
@@ -252,7 +251,7 @@ export class Experiment<I = unknown, O = unknown> {
   }
 }
 
-/** Builder mirroring the Java `Experiment.Builder<I, O>`. */
+/** Builder for {@link Experiment}. */
 export class ExperimentBuilder<I = unknown, O = unknown> {
   /** @internal */ readonly client: ExperimentsClient;
   /** @internal */ _name = "";

--- a/experiments/node-sdk/src/ExperimentResult.ts
+++ b/experiments/node-sdk/src/ExperimentResult.ts
@@ -1,8 +1,8 @@
 /**
- * One row of an experiment run — mirrors the Java `ExperimentResult.Row`.
+ * One row of an experiment run.
  *
  * Implemented as a class (rather than a plain object) so `isError` is a derived
- * accessor, matching the Java getter `isError()`.
+ * accessor.
  */
 export class Row {
   readonly index: number;
@@ -51,7 +51,7 @@ export class Row {
   }
 }
 
-/** Returned by `Experiment.run()` — mirrors the Java `ExperimentResult`. */
+/** Returned by `Experiment.run()`. */
 export class ExperimentResult {
   readonly experimentId: string;
   readonly rows: Row[];

--- a/experiments/node-sdk/src/ExperimentResult.ts
+++ b/experiments/node-sdk/src/ExperimentResult.ts
@@ -1,0 +1,65 @@
+/**
+ * One row of an experiment run — mirrors the Java `ExperimentResult.Row`.
+ *
+ * Implemented as a class (rather than a plain object) so `isError` is a derived
+ * accessor, matching the Java getter `isError()`.
+ */
+export class Row {
+  readonly index: number;
+  readonly spanId: string;
+  readonly traceId: string;
+  readonly startNs: number;
+  readonly durationNs: number;
+  readonly input: unknown;
+  readonly output: unknown;
+  readonly expectedOutput: unknown;
+  readonly errorType: string | null;
+  readonly errorMessage: string | null;
+  readonly evaluations: Record<string, unknown>;
+  readonly evaluationErrors: Record<string, string>;
+
+  constructor(args: {
+    index: number;
+    spanId: string;
+    traceId: string;
+    startNs: number;
+    durationNs: number;
+    input: unknown;
+    output: unknown;
+    expectedOutput: unknown;
+    errorType: string | null;
+    errorMessage: string | null;
+    evaluations: Record<string, unknown>;
+    evaluationErrors: Record<string, string>;
+  }) {
+    this.index = args.index;
+    this.spanId = args.spanId;
+    this.traceId = args.traceId;
+    this.startNs = args.startNs;
+    this.durationNs = args.durationNs;
+    this.input = args.input;
+    this.output = args.output;
+    this.expectedOutput = args.expectedOutput;
+    this.errorType = args.errorType;
+    this.errorMessage = args.errorMessage;
+    this.evaluations = args.evaluations;
+    this.evaluationErrors = args.evaluationErrors;
+  }
+
+  get isError(): boolean {
+    return this.errorType !== null;
+  }
+}
+
+/** Returned by `Experiment.run()` — mirrors the Java `ExperimentResult`. */
+export class ExperimentResult {
+  readonly experimentId: string;
+  readonly rows: Row[];
+  readonly url: string;
+
+  constructor(experimentId: string, rows: Row[], url: string) {
+    this.experimentId = experimentId;
+    this.rows = rows;
+    this.url = url;
+  }
+}

--- a/experiments/node-sdk/src/ExperimentsClient.ts
+++ b/experiments/node-sdk/src/ExperimentsClient.ts
@@ -34,9 +34,8 @@ export interface ExperimentsClientOptions {
 /**
  * Auth + site + project; the factory for everything else.
  *
- * Object-argument constructor, mirroring the Java `ExperimentsClient.builder()`
- * surface. A static `builder()` is also provided so code reads the same as the
- * Java/other-language examples.
+ * Constructed with an options object; a static `builder()` is also provided for a
+ * fluent style.
  */
 export class ExperimentsClient {
   private readonly creds: ApiCredentials;
@@ -62,7 +61,7 @@ export class ExperimentsClient {
     );
   }
 
-  /** Fluent builder, parity with the Java `ExperimentsClient.builder()`. */
+  /** Fluent builder alternative to the options-object constructor. */
   static builder(): ExperimentsClientBuilder {
     return new ExperimentsClientBuilder();
   }
@@ -91,10 +90,9 @@ export class ExperimentsClient {
   }
 
   /**
-   * Escape hatch: the underlying generated `LLMObservabilityApi`.
-   *
-   * Parity with the Java SDK's `api()`. Use it to reach LLM Obs endpoints the six
-   * public types do not model (annotation queues, custom evals, deletes, etc.).
+   * Escape hatch: the underlying generated `LLMObservabilityApi`. Use it to reach
+   * LLM Obs endpoints the six public types do not model (annotation queues,
+   * custom evals, deletes, etc.).
    */
   api(): v2.LLMObservabilityApi {
     return this._api;
@@ -227,7 +225,7 @@ function unwrapAnyValue(value: unknown): unknown {
   return value;
 }
 
-/** Fluent builder mirroring the Java `ExperimentsClient.Builder`. */
+/** Fluent builder for {@link ExperimentsClient}. */
 export class ExperimentsClientBuilder {
   private _apiKey = "";
   private _appKey = "";

--- a/experiments/node-sdk/src/ExperimentsClient.ts
+++ b/experiments/node-sdk/src/ExperimentsClient.ts
@@ -1,0 +1,217 @@
+import type { v2 } from "@datadog/datadog-api-client";
+import { Dataset } from "./Dataset.js";
+import { DatasetRecord } from "./DatasetRecord.js";
+import { buildLlmObsApi, type HttpLibrary } from "./internal/generatedClient.js";
+import type { ApiCredentials } from "./internal/http.js";
+
+export interface ExperimentsClientOptions {
+  apiKey: string;
+  applicationKey: string;
+  /** Bare site host. Defaults to "datadoghq.com". */
+  site?: string;
+  projectName: string;
+  /**
+   * @internal — inject a custom `HttpLibrary` into the generated client. Used by
+   * the test suite to mock transport; not part of the public contract.
+   */
+  httpApi?: HttpLibrary;
+}
+
+/**
+ * Auth + site + project; the factory for everything else.
+ *
+ * Object-argument constructor, mirroring the Java `ExperimentsClient.builder()`
+ * surface. A static `builder()` is also provided so code reads the same as the
+ * Java/other-language examples.
+ */
+export class ExperimentsClient {
+  private readonly creds: ApiCredentials;
+  private readonly _projectName: string;
+  private readonly _api: v2.LLMObservabilityApi;
+  private cachedProjectId: string | null = null;
+
+  constructor(options: ExperimentsClientOptions) {
+    if (!options.apiKey) throw new Error("apiKey is required");
+    if (!options.applicationKey) throw new Error("applicationKey is required");
+    if (!options.projectName) throw new Error("projectName is required");
+    this.creds = {
+      apiKey: options.apiKey,
+      appKey: options.applicationKey,
+      site: options.site ?? "datadoghq.com",
+    };
+    this._projectName = options.projectName;
+    this._api = buildLlmObsApi(
+      this.creds.apiKey,
+      this.creds.appKey,
+      this.creds.site,
+      options.httpApi,
+    );
+  }
+
+  /** Fluent builder, parity with the Java `ExperimentsClient.builder()`. */
+  static builder(): ExperimentsClientBuilder {
+    return new ExperimentsClientBuilder();
+  }
+
+  projectName(): string {
+    return this._projectName;
+  }
+
+  site(): string {
+    return this.creds.site;
+  }
+
+  /** @internal — used by Dataset/Experiment for the hand-rolled HTTP calls (W1/W2/status). */
+  apiKey(): string {
+    return this.creds.apiKey;
+  }
+
+  /** @internal */
+  applicationKey(): string {
+    return this.creds.appKey;
+  }
+
+  /** @internal — credentials bundle for the internal HTTP helpers. */
+  credentials(): ApiCredentials {
+    return this.creds;
+  }
+
+  /**
+   * Escape hatch: the underlying generated `LLMObservabilityApi`.
+   *
+   * Parity with the Java SDK's `api()`. Use it to reach LLM Obs endpoints the six
+   * public types do not model (annotation queues, custom evals, deletes, etc.).
+   */
+  api(): v2.LLMObservabilityApi {
+    return this._api;
+  }
+
+  /** Create a local dataset buffer. Pushed remotely on first `experiment.run()`. */
+  createDataset(name: string, description = ""): Dataset {
+    return new Dataset(this, name, description);
+  }
+
+  /**
+   * Resolve the project id for `projectName`, creating the project if it does not
+   * already exist. The create endpoint is get-or-create on name, so a repeated
+   * call simply returns the existing id. Cached after the first resolution.
+   */
+  async ensureProjectId(): Promise<string> {
+    if (this.cachedProjectId !== null) return this.cachedProjectId;
+    try {
+      const resp = await this._api.createLLMObsProject({
+        body: { data: { type: "projects", attributes: { name: this._projectName } } },
+      });
+      this.cachedProjectId = String(resp?.data?.id ?? "");
+      return this.cachedProjectId;
+    } catch (err) {
+      throw new Error(
+        `Failed to create or get project '${this._projectName}': ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Pull an existing dataset by name (with its records) from the current project.
+   * Retries the list a few times to absorb read-after-write lag, mirroring the
+   * Java `pullDataset`.
+   */
+  async pullDataset(name: string): Promise<Dataset> {
+    const projectId = await this.ensureProjectId();
+
+    let datasetId: string | null = null;
+    let description = "";
+    let lastError = "";
+    for (let attempt = 0; attempt < 3 && datasetId === null; attempt++) {
+      try {
+        const resp = await this._api.listLLMObsDatasets({ projectId, filterName: name });
+        for (const item of resp?.data ?? []) {
+          if (item?.attributes?.name === name) {
+            datasetId = String(item?.id ?? "");
+            description = String(item?.attributes?.description ?? "");
+            break;
+          }
+        }
+      } catch (err) {
+        lastError = (err as Error).message;
+      }
+    }
+
+    if (datasetId === null) {
+      if (lastError) {
+        throw new Error(`Failed to list datasets in project '${this._projectName}': ${lastError}`);
+      }
+      throw new Error(`Dataset '${name}' not found in project '${this._projectName}' (after retries)`);
+    }
+
+    // Fetch the records.
+    const records: DatasetRecord[] = [];
+    const recordIds: string[] = [];
+    try {
+      const resp = await this._api.listLLMObsDatasetRecords({ projectId, datasetId });
+      for (const item of resp?.data ?? []) {
+        records.push(
+          new DatasetRecord(
+            unwrapAnyValue((item as any)?.input) ?? null,
+            unwrapAnyValue((item as any)?.expectedOutput) ?? null,
+            (unwrapAnyValue((item as any)?.metadata) as Record<string, unknown>) ?? {},
+          ),
+        );
+        recordIds.push(String(item?.id ?? ""));
+      }
+    } catch (err) {
+      throw new Error(`Failed to parse records for dataset '${name}': ${(err as Error).message}`);
+    }
+
+    return Dataset.fromExisting(this, name, description, datasetId, projectId, records, recordIds);
+  }
+}
+
+/**
+ * The generated client deserializes `AnyValue` fields (record input / expected
+ * output / metadata) into an `UnparsedObject` wrapper of the form
+ * `{ _data: <raw> }`. Unwrap it back to the raw JSON value.
+ */
+function unwrapAnyValue(value: unknown): unknown {
+  if (value && typeof value === "object" && "_data" in (value as Record<string, unknown>)) {
+    return (value as { _data: unknown })._data;
+  }
+  return value;
+}
+
+/** Fluent builder mirroring the Java `ExperimentsClient.Builder`. */
+export class ExperimentsClientBuilder {
+  private _apiKey = "";
+  private _appKey = "";
+  private _site = "datadoghq.com";
+  private _projectName = "";
+
+  apiKey(apiKey: string): this {
+    this._apiKey = apiKey;
+    return this;
+  }
+
+  applicationKey(appKey: string): this {
+    this._appKey = appKey;
+    return this;
+  }
+
+  site(site: string): this {
+    this._site = site;
+    return this;
+  }
+
+  projectName(projectName: string): this {
+    this._projectName = projectName;
+    return this;
+  }
+
+  build(): ExperimentsClient {
+    return new ExperimentsClient({
+      apiKey: this._apiKey,
+      applicationKey: this._appKey,
+      site: this._site,
+      projectName: this._projectName,
+    });
+  }
+}

--- a/experiments/node-sdk/src/ExperimentsClient.ts
+++ b/experiments/node-sdk/src/ExperimentsClient.ts
@@ -1,8 +1,22 @@
 import type { v2 } from "@datadog/datadog-api-client";
 import { Dataset } from "./Dataset.js";
 import { DatasetRecord } from "./DatasetRecord.js";
+import { retryWithBackoff } from "./internal/backoff.js";
 import { buildLlmObsApi, type HttpLibrary } from "./internal/generatedClient.js";
 import type { ApiCredentials } from "./internal/http.js";
+
+/** Options for {@link ExperimentsClient.pullDataset}. */
+export interface PullDatasetOptions {
+  /**
+   * Wait (with exponential backoff) until at least this many records are
+   * readable from the backend. Use when pulling right after a push, to absorb
+   * read-after-write lag. If omitted, the pull only waits for the dataset itself
+   * to become visible.
+   */
+  expectedRecordCount?: number;
+  /** Maximum total time to wait for the dataset/records to appear. Default 30s. */
+  maxWaitMs?: number;
+}
 
 export interface ExperimentsClientOptions {
   apiKey: string;
@@ -113,54 +127,87 @@ export class ExperimentsClient {
 
   /**
    * Pull an existing dataset by name (with its records) from the current project.
-   * Retries the list a few times to absorb read-after-write lag, mirroring the
-   * Java `pullDataset`.
+   *
+   * Reads on the LLM Obs API are eventually consistent, so a pull issued right
+   * after a push can momentarily see the dataset missing or only some of its
+   * records. This polls with exponential backoff (up to `maxWaitMs`, default 30s)
+   * until the dataset is visible and — when `expectedRecordCount` is given — at
+   * least that many records are readable, confirming the push fully landed.
    */
-  async pullDataset(name: string): Promise<Dataset> {
+  async pullDataset(name: string, options: PullDatasetOptions = {}): Promise<Dataset> {
     const projectId = await this.ensureProjectId();
+    const { expectedRecordCount, maxWaitMs = 30_000 } = options;
 
     let datasetId: string | null = null;
     let description = "";
+    let records: DatasetRecord[] = [];
+    let recordIds: string[] = [];
     let lastError = "";
-    for (let attempt = 0; attempt < 3 && datasetId === null; attempt++) {
+
+    const succeeded = await retryWithBackoff(async () => {
       try {
-        const resp = await this._api.listLLMObsDatasets({ projectId, filterName: name });
-        for (const item of resp?.data ?? []) {
-          if (item?.attributes?.name === name) {
-            datasetId = String(item?.id ?? "");
-            description = String(item?.attributes?.description ?? "");
-            break;
+        // 1. Find the dataset by name.
+        if (datasetId === null) {
+          const listed = await this._api.listLLMObsDatasets({ projectId, filterName: name });
+          for (const item of listed?.data ?? []) {
+            if (item?.attributes?.name === name) {
+              datasetId = String(item?.id ?? "");
+              description = String(item?.attributes?.description ?? "");
+              break;
+            }
           }
+          if (datasetId === null) return false; // not visible yet — keep waiting
         }
+
+        // 2. Fetch its records via the generated client.
+        //
+        // Spec drift: the API returns record content nested under
+        // data[].attributes (JSON:API), but the generated
+        // LLMObsDatasetRecordDataResponse model is flat (input/expected_output/
+        // metadata at the top level). The deserializer therefore can't map the
+        // nested object onto the typed fields (they come back undefined) and
+        // instead stashes the whole `attributes` object under
+        // `additionalProperties`. Read from there, falling back to the typed
+        // fields in case the API/model are realigned later.
+        const recs: DatasetRecord[] = [];
+        const ids: string[] = [];
+        const resp = await this._api.listLLMObsDatasetRecords({ projectId, datasetId });
+        for (const item of resp?.data ?? []) {
+          const nested = (item as any)?.additionalProperties?.attributes;
+          const src = nested ?? item;
+          recs.push(
+            new DatasetRecord(
+              unwrapAnyValue(src?.input) ?? null,
+              unwrapAnyValue(src?.expected_output ?? src?.expectedOutput) ?? null,
+              (unwrapAnyValue(src?.metadata) as Record<string, unknown>) ?? {},
+            ),
+          );
+          ids.push(String(item?.id ?? ""));
+        }
+        records = recs;
+        recordIds = ids;
+
+        // 3. If a count was expected, keep waiting until everything has landed.
+        if (expectedRecordCount != null && recs.length < expectedRecordCount) {
+          return false;
+        }
+        return true;
       } catch (err) {
         lastError = (err as Error).message;
+        return false; // transient read error — retry within the budget
       }
-    }
+    }, { maxTotalMs: maxWaitMs });
 
     if (datasetId === null) {
       if (lastError) {
         throw new Error(`Failed to list datasets in project '${this._projectName}': ${lastError}`);
       }
-      throw new Error(`Dataset '${name}' not found in project '${this._projectName}' (after retries)`);
+      throw new Error(`Dataset '${name}' not found in project '${this._projectName}' (after ${maxWaitMs}ms)`);
     }
-
-    // Fetch the records.
-    const records: DatasetRecord[] = [];
-    const recordIds: string[] = [];
-    try {
-      const resp = await this._api.listLLMObsDatasetRecords({ projectId, datasetId });
-      for (const item of resp?.data ?? []) {
-        records.push(
-          new DatasetRecord(
-            unwrapAnyValue((item as any)?.input) ?? null,
-            unwrapAnyValue((item as any)?.expectedOutput) ?? null,
-            (unwrapAnyValue((item as any)?.metadata) as Record<string, unknown>) ?? {},
-          ),
-        );
-        recordIds.push(String(item?.id ?? ""));
-      }
-    } catch (err) {
-      throw new Error(`Failed to parse records for dataset '${name}': ${(err as Error).message}`);
+    if (!succeeded && expectedRecordCount != null) {
+      throw new Error(
+        `Dataset '${name}' has ${records.length} record(s) after ${maxWaitMs}ms, expected ${expectedRecordCount} — backend may not have finished ingesting the push`,
+      );
     }
 
     return Dataset.fromExisting(this, name, description, datasetId, projectId, records, recordIds);
@@ -168,9 +215,10 @@ export class ExperimentsClient {
 }
 
 /**
- * The generated client deserializes `AnyValue` fields (record input / expected
- * output / metadata) into an `UnparsedObject` wrapper of the form
- * `{ _data: <raw> }`. Unwrap it back to the raw JSON value.
+ * Record `input` / `expectedOutput` are typed `AnyValue` in the generated model;
+ * the deserializer wraps some scalar values in an `UnparsedObject` of the form
+ * `{ _data: <raw> }`. Unwrap it back to the raw JSON value. (Values read out of
+ * `additionalProperties` are already raw and pass through unchanged.)
  */
 function unwrapAnyValue(value: unknown): unknown {
   if (value && typeof value === "object" && "_data" in (value as Record<string, unknown>)) {

--- a/experiments/node-sdk/src/Task.ts
+++ b/experiments/node-sdk/src/Task.ts
@@ -1,0 +1,11 @@
+/**
+ * User-provided task: `(input, config) -> output`.
+ *
+ * Equivalent to the Java `Task<I, O>` functional interface. May be sync or async
+ * (return a value or a Promise). Any thrown error / rejected promise is captured
+ * per-row in the span without aborting the experiment (see Experiment.run).
+ */
+export type Task<I = unknown, O = unknown> = (
+  input: I,
+  config: Record<string, unknown>,
+) => O | Promise<O>;

--- a/experiments/node-sdk/src/Task.ts
+++ b/experiments/node-sdk/src/Task.ts
@@ -1,9 +1,9 @@
 /**
  * User-provided task: `(input, config) -> output`.
  *
- * Equivalent to the Java `Task<I, O>` functional interface. May be sync or async
- * (return a value or a Promise). Any thrown error / rejected promise is captured
- * per-row in the span without aborting the experiment (see Experiment.run).
+ * May be sync or async (return a value or a Promise). Any thrown error / rejected
+ * promise is captured per-row in the span without aborting the experiment (see
+ * Experiment.run).
  */
 export type Task<I = unknown, O = unknown> = (
   input: I,

--- a/experiments/node-sdk/src/index.ts
+++ b/experiments/node-sdk/src/index.ts
@@ -2,7 +2,7 @@
  * Datadog LLM Experiments — Node.js / TypeScript SDK.
  *
  * A thin workflow layer over the Datadog LLM Observability API for running LLM
- * experiments. Interface parity with the Java SDK (`datadog-llm-experiments-java`).
+ * experiments.
  */
 export { ExperimentsClient, ExperimentsClientBuilder } from "./ExperimentsClient.js";
 export type { ExperimentsClientOptions, PullDatasetOptions } from "./ExperimentsClient.js";

--- a/experiments/node-sdk/src/index.ts
+++ b/experiments/node-sdk/src/index.ts
@@ -5,7 +5,7 @@
  * experiments. Interface parity with the Java SDK (`datadog-llm-experiments-java`).
  */
 export { ExperimentsClient, ExperimentsClientBuilder } from "./ExperimentsClient.js";
-export type { ExperimentsClientOptions } from "./ExperimentsClient.js";
+export type { ExperimentsClientOptions, PullDatasetOptions } from "./ExperimentsClient.js";
 export { Dataset } from "./Dataset.js";
 export { DatasetRecord } from "./DatasetRecord.js";
 export { Experiment, ExperimentBuilder } from "./Experiment.js";

--- a/experiments/node-sdk/src/index.ts
+++ b/experiments/node-sdk/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Datadog LLM Experiments — Node.js / TypeScript SDK.
+ *
+ * A thin workflow layer over the Datadog LLM Observability API for running LLM
+ * experiments. Interface parity with the Java SDK (`datadog-llm-experiments-java`).
+ */
+export { ExperimentsClient, ExperimentsClientBuilder } from "./ExperimentsClient.js";
+export type { ExperimentsClientOptions } from "./ExperimentsClient.js";
+export { Dataset } from "./Dataset.js";
+export { DatasetRecord } from "./DatasetRecord.js";
+export { Experiment, ExperimentBuilder } from "./Experiment.js";
+export { ExperimentResult, Row } from "./ExperimentResult.js";
+export type { Task } from "./Task.js";
+export type { Evaluator } from "./Evaluator.js";

--- a/experiments/node-sdk/src/internal/backoff.ts
+++ b/experiments/node-sdk/src/internal/backoff.ts
@@ -1,0 +1,48 @@
+/**
+ * Exponential-backoff retry helper.
+ *
+ * Used by read-after-write operations (e.g. `pullDataset`) to absorb the
+ * eventual-consistency lag between pushing data and it becoming queryable on the
+ * backend. Delays double each round (250ms, 500ms, 1s, 2s, …) and are capped per
+ * round; the loop stops once the cumulative elapsed time reaches `maxTotalMs`.
+ */
+
+export interface BackoffOptions {
+  /** Hard ceiling on total time spent waiting (sleeps + attempts). Default 30s. */
+  maxTotalMs?: number;
+  /** First sleep, doubled each round. Default 250ms. */
+  baseDelayMs?: number;
+  /** Per-round sleep cap. Default 8s. */
+  maxDelayMs?: number;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `attempt` repeatedly until it returns `true` (success) or the time budget
+ * is exhausted. `attempt` is always invoked at least once. Returns `true` if it
+ * succeeded, `false` if the budget ran out first.
+ */
+export async function retryWithBackoff(
+  attempt: () => Promise<boolean>,
+  options: BackoffOptions = {},
+): Promise<boolean> {
+  const maxTotalMs = options.maxTotalMs ?? 30_000;
+  const baseDelayMs = options.baseDelayMs ?? 250;
+  const maxDelayMs = options.maxDelayMs ?? 8_000;
+
+  const start = Date.now();
+  let delay = baseDelayMs;
+
+  for (;;) {
+    if (await attempt()) return true;
+
+    const elapsed = Date.now() - start;
+    const remaining = maxTotalMs - elapsed;
+    if (remaining <= 0) return false;
+
+    await sleep(Math.min(delay, maxDelayMs, remaining));
+    delay *= 2;
+  }
+}

--- a/experiments/node-sdk/src/internal/generatedClient.ts
+++ b/experiments/node-sdk/src/internal/generatedClient.ts
@@ -44,9 +44,14 @@ function relaxRequiredFlags(): void {
  *   createLLMObsProject, createLLMObsDataset, listLLMObsDatasets,
  *   listLLMObsDatasetRecords, createLLMObsExperiment.
  *
- * The three endpoints with active spec-drift workarounds (records POST → W1,
- * events POST → W2, experiment status PATCH → no model field) are hand-rolled in
- * `http.ts`, exactly as the Java SDK hand-rolls them via `DirectPost`.
+ * Only the three endpoints the generated client genuinely cannot perform are
+ * hand-rolled in `http.ts`, exactly as the Java SDK hand-rolls them via
+ * `DirectPost`: records POST (W1 — wrong `type` discriminator), events POST
+ * (W2 — wrong `type` discriminator), and the experiment status PATCH (the
+ * update model has no `status` field). The records LIST read still goes through
+ * the generated client; its response just needs a small extraction shim because
+ * the flat record model leaves the nested `attributes` under
+ * `additionalProperties` (see ExperimentsClient.pullDataset).
  */
 
 /** Operations the SDK invokes that are flagged "unstable" and must be enabled. */

--- a/experiments/node-sdk/src/internal/generatedClient.ts
+++ b/experiments/node-sdk/src/internal/generatedClient.ts
@@ -30,8 +30,7 @@ function relaxRequiredFlags(): void {
 
 /**
  * Builds the generated `datadog-api-client` LLM Observability API, configured for
- * the SDK's needs. This is the Node analogue of the Java SDK's `ExperimentsClient`
- * constructor:
+ * the SDK's needs:
  *
  *  - W7: construct a fresh `Configuration` via `createConfiguration` rather than
  *    the env-driven default, so `DD_SITE` is never read eagerly.
@@ -45,11 +44,11 @@ function relaxRequiredFlags(): void {
  *   listLLMObsDatasetRecords, createLLMObsExperiment.
  *
  * Only the three endpoints the generated client genuinely cannot perform are
- * hand-rolled in `http.ts`, exactly as the Java SDK hand-rolls them via
- * `DirectPost`: records POST (W1 — wrong `type` discriminator), events POST
- * (W2 — wrong `type` discriminator), and the experiment status PATCH (the
- * update model has no `status` field). The records LIST read still goes through
- * the generated client; its response just needs a small extraction shim because
+ * hand-rolled in `http.ts`: records POST (W1 — wrong `type` discriminator),
+ * events POST (W2 — wrong `type` discriminator), and the experiment status PATCH
+ * (the update model has no `status` field). The records LIST read still goes
+ * through the generated client; its response just needs a small extraction shim
+ * because
  * the flat record model leaves the nested `attributes` under
  * `additionalProperties` (see ExperimentsClient.pullDataset).
  */

--- a/experiments/node-sdk/src/internal/generatedClient.ts
+++ b/experiments/node-sdk/src/internal/generatedClient.ts
@@ -1,0 +1,83 @@
+import { client, v2 } from "@datadog/datadog-api-client";
+
+/**
+ * W5: the generated `ObjectSerializer.deserialize` throws "missing required
+ * property '<x>'" whenever a response omits a field the spec marks `required:
+ * true` (e.g. `created_at`, `description`). Several LLM Obs response models hit
+ * this. The spec's prescribed fix is to "configure the deserializer to ignore the
+ * required flag on response classes" — here we do exactly that, once, by clearing
+ * the `required` flag on every v2 model's attribute map. Relaxing it on request
+ * models too is harmless: the SDK always supplies the fields it sends.
+ */
+let relaxed = false;
+function relaxRequiredFlags(): void {
+  if (relaxed) return;
+  relaxed = true;
+  const ns = v2 as unknown as Record<string, unknown>;
+  for (const key of Object.keys(ns)) {
+    const model = ns[key] as { getAttributeTypeMap?: () => Record<string, { required?: boolean }> };
+    if (typeof model?.getAttributeTypeMap !== "function") continue;
+    try {
+      const map = model.getAttributeTypeMap();
+      for (const attr of Object.keys(map)) {
+        if (map[attr]?.required) map[attr].required = false;
+      }
+    } catch {
+      // best-effort; skip any model whose map can't be read/mutated
+    }
+  }
+}
+
+/**
+ * Builds the generated `datadog-api-client` LLM Observability API, configured for
+ * the SDK's needs. This is the Node analogue of the Java SDK's `ExperimentsClient`
+ * constructor:
+ *
+ *  - W7: construct a fresh `Configuration` via `createConfiguration` rather than
+ *    the env-driven default, so `DD_SITE` is never read eagerly.
+ *  - W6: point at an explicit `baseServer` (`https://api.<site>`) instead of the
+ *    restricted, enum-validated default server — this makes every site work,
+ *    including staging (`datad0g.com`) and GovCloud, with no allow-list errors.
+ *  - Enable the unstable LLM Obs operations the SDK calls.
+ *
+ * The LLM Obs endpoints used through the generated client are:
+ *   createLLMObsProject, createLLMObsDataset, listLLMObsDatasets,
+ *   listLLMObsDatasetRecords, createLLMObsExperiment.
+ *
+ * The three endpoints with active spec-drift workarounds (records POST → W1,
+ * events POST → W2, experiment status PATCH → no model field) are hand-rolled in
+ * `http.ts`, exactly as the Java SDK hand-rolls them via `DirectPost`.
+ */
+
+/** Operations the SDK invokes that are flagged "unstable" and must be enabled. */
+const UNSTABLE_OPERATIONS = [
+  "v2.createLLMObsProject",
+  "v2.createLLMObsDataset",
+  "v2.listLLMObsDatasets",
+  "v2.listLLMObsDatasetRecords",
+  "v2.createLLMObsExperiment",
+];
+
+/** Anything implementing the generated client's `HttpLibrary` (for test injection). */
+export type HttpLibrary = client.HttpLibrary;
+
+export function buildLlmObsApi(
+  apiKey: string,
+  appKey: string,
+  site: string,
+  httpApi?: HttpLibrary,
+): v2.LLMObservabilityApi {
+  relaxRequiredFlags(); // W5
+  const configuration = client.createConfiguration({
+    authMethods: { apiKeyAuth: apiKey, appKeyAuth: appKey },
+    // W6/W7: explicit, unrestricted base server for the chosen site.
+    baseServer: new client.BaseServerConfiguration(`https://api.${site}`, {}),
+    ...(httpApi ? { httpApi } : {}),
+  });
+
+  for (const op of UNSTABLE_OPERATIONS) {
+    configuration.unstableOperations[op] = true;
+  }
+
+  return new v2.LLMObservabilityApi(configuration);
+}

--- a/experiments/node-sdk/src/internal/http.ts
+++ b/experiments/node-sdk/src/internal/http.ts
@@ -4,8 +4,7 @@
  * Used only for the endpoints with active spec-drift workarounds — the records
  * POST (W1), the experiment events POST (W2), and the experiment status PATCH
  * (the generated update model has no `status` field). Everything else goes
- * through the generated `@datadog/datadog-api-client`. This mirrors what the Java
- * SDK's `DirectPost` does.
+ * through the generated `@datadog/datadog-api-client`.
  *
  * Because we build the URL ourselves (`https://api.<site><path>`), the staging
  * site `datad0g.com` and the GovCloud sites just work here too.

--- a/experiments/node-sdk/src/internal/http.ts
+++ b/experiments/node-sdk/src/internal/http.ts
@@ -1,0 +1,94 @@
+/**
+ * Hand-rolled HTTP transport for the Datadog LLM Observability API.
+ *
+ * Used only for the endpoints with active spec-drift workarounds — the records
+ * POST (W1), the experiment events POST (W2), and the experiment status PATCH
+ * (the generated update model has no `status` field). Everything else goes
+ * through the generated `@datadog/datadog-api-client`. This mirrors what the Java
+ * SDK's `DirectPost` does.
+ *
+ * Because we build the URL ourselves (`https://api.<site><path>`), the staging
+ * site `datad0g.com` and the GovCloud sites just work here too.
+ */
+
+export interface ApiCredentials {
+  apiKey: string;
+  appKey: string;
+  /** Bare site host, e.g. "datadoghq.com", "us5.datadoghq.com", "datad0g.com". */
+  site: string;
+}
+
+/** Base URL of the API for a given site: `https://api.<site>`. */
+export function apiBase(site: string): string {
+  return `https://api.${site}`;
+}
+
+/** Base URL of the web app for a given site: `https://app.<site>`. */
+export function appBase(site: string): string {
+  return `https://app.${site}`;
+}
+
+async function send(
+  method: "GET" | "POST" | "PATCH",
+  creds: ApiCredentials,
+  path: string,
+  body?: unknown,
+): Promise<string> {
+  const url = apiBase(creds.site) + path;
+
+  let payload: string | undefined;
+  if (body !== undefined) {
+    try {
+      payload = JSON.stringify(body);
+    } catch (err) {
+      throw new Error(
+        `Failed to serialize request body for ${method} ${path}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  const headers: Record<string, string> = {
+    "DD-API-KEY": creds.apiKey,
+    "DD-APPLICATION-KEY": creds.appKey,
+  };
+  if (payload !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, { method, headers, body: payload });
+  } catch (err) {
+    throw new Error(`${method} ${path} failed: ${(err as Error).message}`);
+  }
+
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`${method} ${path} failed: HTTP ${res.status} ${text}`);
+  }
+  return text;
+}
+
+/** POST a JSON body; discards the response. */
+export async function post(creds: ApiCredentials, path: string, body: unknown): Promise<void> {
+  await send("POST", creds, path, body);
+}
+
+/** PATCH a JSON body; discards the response. */
+export async function patch(creds: ApiCredentials, path: string, body: unknown): Promise<void> {
+  await send("PATCH", creds, path, body);
+}
+
+/** GET; returns the raw response body as a string. */
+export async function get(creds: ApiCredentials, path: string): Promise<string> {
+  return send("GET", creds, path);
+}
+
+/** POST a JSON body; returns the raw response body as a string. */
+export async function postReturning(
+  creds: ApiCredentials,
+  path: string,
+  body: unknown,
+): Promise<string> {
+  return send("POST", creds, path, body);
+}

--- a/experiments/node-sdk/src/internal/ids.ts
+++ b/experiments/node-sdk/src/internal/ids.ts
@@ -1,9 +1,8 @@
 import { randomUUID } from "node:crypto";
 
 /**
- * Generate a 32-character hex id (a UUIDv4 with the dashes stripped), matching
- * the Java SDK's `UUID.randomUUID().toString().replace("-", "")` for span and
- * trace ids.
+ * Generate a 32-character hex id (a UUIDv4 with the dashes stripped) for use as
+ * a span or trace id.
  */
 export function hexId(): string {
   return randomUUID().replace(/-/g, "");

--- a/experiments/node-sdk/src/internal/ids.ts
+++ b/experiments/node-sdk/src/internal/ids.ts
@@ -1,0 +1,10 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Generate a 32-character hex id (a UUIDv4 with the dashes stripped), matching
+ * the Java SDK's `UUID.randomUUID().toString().replace("-", "")` for span and
+ * trace ids.
+ */
+export function hexId(): string {
+  return randomUUID().replace(/-/g, "");
+}

--- a/experiments/node-sdk/src/internal/metricBuilder.ts
+++ b/experiments/node-sdk/src/internal/metricBuilder.ts
@@ -1,0 +1,71 @@
+/**
+ * Build one metric map per evaluator per row (the LLM Obs metric wire format).
+ *
+ * The metric type is inferred from the evaluator's return value:
+ *   - boolean -> "boolean", value under `boolean_value`
+ *   - number  -> "score",   value under `score_value`
+ *   - other   -> "categorical", value stringified under `categorical_value`
+ *
+ * If `errorMessage` is set the metric carries an `error` instead of a value.
+ * The auto tag `experiment_id` always wins over user tags.
+ */
+export function toMetric(
+  label: string,
+  value: unknown,
+  errorMessage: string | null,
+  spanId: string,
+  timestampMs: number,
+  experimentId: string,
+  userTags: Record<string, string>,
+): Record<string, unknown> {
+  const metric: Record<string, unknown> = {
+    label,
+    span_id: spanId,
+    timestamp_ms: timestampMs,
+    tags: buildTags(userTags, experimentId),
+  };
+
+  if (errorMessage !== null) {
+    // Type is irrelevant on an errored metric, but the wire shape still needs one.
+    metric.metric_type = "categorical";
+    metric.error = { message: errorMessage };
+    return metric;
+  }
+
+  const type = inferType(value);
+  metric.metric_type = type;
+  switch (type) {
+    case "boolean":
+      metric.boolean_value = value as boolean;
+      break;
+    case "score":
+      metric.score_value = value as number;
+      break;
+    default:
+      metric.categorical_value = stringify(value);
+      break;
+  }
+  return metric;
+}
+
+function inferType(value: unknown): "boolean" | "score" | "categorical" {
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number" && Number.isFinite(value)) return "score";
+  return "categorical";
+}
+
+function stringify(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function buildTags(userTags: Record<string, string>, experimentId: string): string[] {
+  const tags = new Map<string, string>();
+  for (const [k, v] of Object.entries(userTags ?? {})) {
+    tags.set(k, `${k}:${v}`);
+  }
+  tags.set("experiment_id", `experiment_id:${experimentId}`);
+  return [...tags.values()];
+}

--- a/experiments/node-sdk/src/internal/spanBuilder.ts
+++ b/experiments/node-sdk/src/internal/spanBuilder.ts
@@ -1,0 +1,69 @@
+import type { Row } from "../ExperimentResult.js";
+
+/**
+ * Build the raw span map for one experiment row (the LLM Obs experiment span
+ * wire format).
+ *
+ * Tag precedence: the auto tags `experiment_id`, `dataset_id`,
+ * `dataset_record_id` always win over user-supplied tags on key conflict.
+ * `metadata` lives only in `meta.metadata` — never in tags.
+ */
+export function toSpan(
+  row: Row,
+  metadata: Record<string, unknown>,
+  experimentId: string,
+  projectId: string,
+  datasetId: string,
+  datasetRecordId: string,
+  spanName: string,
+  userTags: Record<string, string>,
+): Record<string, unknown> {
+  const meta: Record<string, unknown> = {
+    input: row.input ?? null,
+    output: row.output ?? null,
+    expected_output: row.expectedOutput ?? null,
+  };
+
+  // metadata: raw / unwrapped. Only emitted when present (W4).
+  if (metadata && Object.keys(metadata).length > 0) {
+    meta.metadata = metadata;
+  }
+
+  if (row.isError) {
+    meta.error = {
+      type: row.errorType ?? "",
+      message: row.errorMessage ?? "",
+      stack: "",
+    };
+  }
+
+  return {
+    span_id: row.spanId,
+    trace_id: row.traceId,
+    project_id: projectId,
+    dataset_id: datasetId,
+    name: spanName,
+    start_ns: row.startNs,
+    duration: row.durationNs,
+    status: row.isError ? "error" : "ok",
+    meta,
+    tags: buildTags(userTags, experimentId, datasetId, datasetRecordId),
+  };
+}
+
+function buildTags(
+  userTags: Record<string, string>,
+  experimentId: string,
+  datasetId: string,
+  datasetRecordId: string,
+): string[] {
+  const tags = new Map<string, string>();
+  // User tags first, so the auto tags below overwrite on conflict.
+  for (const [k, v] of Object.entries(userTags ?? {})) {
+    tags.set(k, `${k}:${v}`);
+  }
+  tags.set("experiment_id", `experiment_id:${experimentId}`);
+  tags.set("dataset_id", `dataset_id:${datasetId}`);
+  tags.set("dataset_record_id", `dataset_record_id:${datasetRecordId}`);
+  return [...tags.values()];
+}

--- a/experiments/node-sdk/test/client.test.ts
+++ b/experiments/node-sdk/test/client.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+import { ExperimentsClient } from "../src/index.js";
+import { MockFetch, defaultRoutes } from "./mockFetch.js";
+
+let mock: MockFetch;
+beforeEach(() => {
+  mock = new MockFetch(defaultRoutes());
+  mock.install();
+});
+afterEach(() => mock.restore());
+
+test("object-arg constructor and static builder() are equivalent", () => {
+  const a = new ExperimentsClient({
+    apiKey: "k",
+    applicationKey: "a",
+    site: "us5.datadoghq.com",
+    projectName: "p",
+  });
+  const b = ExperimentsClient.builder()
+    .apiKey("k")
+    .applicationKey("a")
+    .site("us5.datadoghq.com")
+    .projectName("p")
+    .build();
+  assert.equal(a.projectName(), b.projectName());
+  assert.equal(a.site(), b.site());
+  assert.equal(a.site(), "us5.datadoghq.com");
+});
+
+test("site defaults to datadoghq.com", () => {
+  const c = new ExperimentsClient({ apiKey: "k", applicationKey: "a", projectName: "p" });
+  assert.equal(c.site(), "datadoghq.com");
+});
+
+test("constructor validates required fields", () => {
+  assert.throws(
+    () => new ExperimentsClient({ apiKey: "", applicationKey: "a", projectName: "p" }),
+    /apiKey/,
+  );
+  assert.throws(
+    () => new ExperimentsClient({ apiKey: "k", applicationKey: "", projectName: "p" }),
+    /applicationKey/,
+  );
+  assert.throws(
+    () => new ExperimentsClient({ apiKey: "k", applicationKey: "a", projectName: "" }),
+    /projectName/,
+  );
+});
+
+test("ensureProjectId creates-or-gets the project (via the generated client) and caches the id", async () => {
+  const c = new ExperimentsClient({
+    apiKey: "k",
+    applicationKey: "a",
+    projectName: "my-proj",
+    httpApi: mock.httpLibrary,
+  });
+  const id1 = await c.ensureProjectId();
+  const id2 = await c.ensureProjectId();
+  assert.equal(id1, "proj-1");
+  assert.equal(id2, "proj-1");
+  // cached — only one POST despite two calls
+  const posts = mock.matching("POST /api/v2/llm-obs/v1/projects");
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].via, "generated", "project create goes through the generated client");
+  assert.equal(posts[0].body.data.type, "projects");
+  assert.equal(posts[0].body.data.attributes.name, "my-proj");
+  // generated client attaches the DD auth headers
+  assert.equal(posts[0].headers["DD-API-KEY"], "k");
+  assert.equal(posts[0].headers["DD-APPLICATION-KEY"], "a");
+});
+
+test("api() escape hatch returns the generated LLMObservabilityApi", async () => {
+  const c = new ExperimentsClient({
+    apiKey: "k",
+    applicationKey: "a",
+    projectName: "p",
+    httpApi: mock.httpLibrary,
+  });
+  const api = c.api();
+  // It's the generated client, so generated operations are available directly.
+  assert.equal(typeof api.createLLMObsProject, "function");
+  assert.equal(typeof api.listLLMObsExperiments, "function");
+  const resp = await api.createLLMObsProject({
+    body: { data: { type: "projects", attributes: { name: "p" } } },
+  });
+  assert.equal(resp.data?.id, "proj-1");
+});

--- a/experiments/node-sdk/test/dataset.test.ts
+++ b/experiments/node-sdk/test/dataset.test.ts
@@ -118,11 +118,10 @@ test("pullDataset finds a dataset by name and loads its records", async () => {
     {
       match: "GET /api/v2/llm-obs/v1/proj-1/datasets/ds-9/records",
       response: {
-        // The generated record model carries input/expected_output/metadata at the
-        // top level of each data item (not under `attributes`).
+        // The API returns record content nested under data[].attributes (JSON:API).
         data: [
-          { id: "r1", input: "i1", expected_output: "e1", metadata: { a: 1 } },
-          { id: "r2", input: "i2" },
+          { id: "r1", type: "datasets", attributes: { input: "i1", expected_output: "e1", metadata: { a: 1 } } },
+          { id: "r2", type: "datasets", attributes: { input: "i2" } },
         ],
       },
     },
@@ -155,5 +154,57 @@ test("pullDataset throws a clear error when the dataset is absent", async () => 
     { match: "GET /api/v2/llm-obs/v1/proj-1/datasets", response: { data: [] } },
   ]);
   mock.install();
-  await assert.rejects(() => newClient().pullDataset("ghost"), /not found.*after retries/);
+  // maxWaitMs: 0 → a single attempt, no 30s wait, in the test.
+  await assert.rejects(() => newClient().pullDataset("ghost", { maxWaitMs: 0 }), /not found/);
+});
+
+test("pullDataset waits (backoff) until all expected records are readable", async () => {
+  mock.restore();
+  let recordsCalls = 0;
+  mock = new MockFetch([
+    { match: "POST /api/v2/llm-obs/v1/projects", response: { data: { id: "proj-1" } } },
+    {
+      match: "GET /api/v2/llm-obs/v1/proj-1/datasets/ds-9/records",
+      response: () => {
+        // First read sees only 1 of 2 records (read-after-write lag); then both.
+        recordsCalls += 1;
+        const rec = (id: string, input: string) => ({ id, type: "datasets", attributes: { input } });
+        return recordsCalls < 2
+          ? { data: [rec("r1", "i1")] }
+          : { data: [rec("r1", "i1"), rec("r2", "i2")] };
+      },
+    },
+    {
+      match: "GET /api/v2/llm-obs/v1/proj-1/datasets",
+      response: { data: [{ id: "ds-9", attributes: { name: "wanted" } }] },
+    },
+  ]);
+  mock.install();
+
+  const ds = await newClient().pullDataset("wanted", {
+    expectedRecordCount: 2,
+    maxWaitMs: 5000, // generous ceiling; the first retry (~250ms) already satisfies it
+  });
+  assert.equal(ds.records().length, 2);
+  assert.ok(recordsCalls >= 2, "records endpoint was polled more than once");
+});
+
+test("pullDataset throws if expected records never arrive within the budget", async () => {
+  mock.restore();
+  mock = new MockFetch([
+    { match: "POST /api/v2/llm-obs/v1/projects", response: { data: { id: "proj-1" } } },
+    {
+      match: "GET /api/v2/llm-obs/v1/proj-1/datasets/ds-9/records",
+      response: { data: [{ id: "r1", type: "datasets", attributes: { input: "i1" } }] }, // only ever 1 record
+    },
+    {
+      match: "GET /api/v2/llm-obs/v1/proj-1/datasets",
+      response: { data: [{ id: "ds-9", attributes: { name: "wanted" } }] },
+    },
+  ]);
+  mock.install();
+  await assert.rejects(
+    () => newClient().pullDataset("wanted", { expectedRecordCount: 3, maxWaitMs: 0 }),
+    /expected 3.*backend may not have finished ingesting/,
+  );
 });

--- a/experiments/node-sdk/test/dataset.test.ts
+++ b/experiments/node-sdk/test/dataset.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+import { Dataset, DatasetRecord, ExperimentsClient } from "../src/index.js";
+import { MockFetch, defaultRoutes } from "./mockFetch.js";
+
+let mock: MockFetch;
+
+function newClient(): ExperimentsClient {
+  return new ExperimentsClient({
+    apiKey: "key",
+    applicationKey: "app",
+    site: "datadoghq.com",
+    projectName: "my-project",
+    httpApi: mock.httpLibrary,
+  });
+}
+
+beforeEach(() => {
+  mock = new MockFetch(defaultRoutes());
+  mock.install();
+});
+afterEach(() => mock.restore());
+
+test("createDataset returns an unpushed, empty buffer", () => {
+  const ds = newClient().createDataset("d", "desc");
+  assert.equal(ds.name(), "d");
+  assert.equal(ds.id(), null);
+  assert.equal(ds.projectId(), null);
+  assert.deepEqual([...ds.records()], []);
+});
+
+test("addRecord is fluent and accepts both shapes", () => {
+  const ds = newClient().createDataset("d");
+  const ret = ds
+    .addRecord("in1", "out1", { team: "a" })
+    .addRecord(new DatasetRecord("in2", "out2"));
+  assert.equal(ret, ds, "addRecord returns the dataset for chaining");
+  const recs = ds.records();
+  assert.equal(recs.length, 2);
+  assert.equal(recs[0].input, "in1");
+  assert.deepEqual(recs[0].metadata, { team: "a" });
+  assert.equal(recs[1].expectedOutput, "out2");
+});
+
+test("push creates the dataset and sends records with type 'datasets' (W1)", async () => {
+  const ds = newClient().createDataset("d", "the desc");
+  ds.addRecord("hello", "world", { file: "f.txt" });
+  ds.addRecord("foo"); // no expected_output, no metadata
+  await ds.push();
+
+  assert.equal(ds.id(), "ds-1");
+  assert.equal(ds.projectId(), "proj-1");
+
+  // Dataset create body
+  const createReq = mock.matching("POST /api/v2/llm-obs/v1/proj-1/datasets")
+    .filter((r) => !r.path.endsWith("/records"))[0];
+  assert.ok(createReq, "dataset create was called");
+  assert.equal(createReq.body.data.type, "datasets");
+  assert.equal(createReq.body.data.attributes.name, "d");
+  assert.equal(createReq.body.data.attributes.description, "the desc");
+
+  // Records push body
+  const recReq = mock.matching("POST /api/v2/llm-obs/v1/proj-1/datasets/ds-1/records")[0];
+  assert.ok(recReq, "records push was called");
+  assert.equal(recReq.body.data.type, "datasets");
+  const records = recReq.body.data.attributes.records;
+  assert.equal(records.length, 2);
+  assert.deepEqual(records[0], {
+    input: "hello",
+    expected_output: "world",
+    metadata: { file: "f.txt" },
+  });
+  // Second record omits expected_output and metadata entirely.
+  assert.deepEqual(records[1], { input: "foo" });
+
+  // Record ids captured from the response, aligned by index.
+  assert.deepEqual([...ds.recordIds()], ["rec-0", "rec-1"]);
+});
+
+test("dataset url() is null until pushed, then links to the dataset", async () => {
+  const ds = newClient().createDataset("d");
+  assert.equal(ds.url(), null);
+  ds.addRecord("a");
+  await ds.push();
+  assert.equal(ds.url(), "https://app.datadoghq.com/llm/datasets/ds-1");
+});
+
+test("push is incremental — only new records are sent on the second push", async () => {
+  const ds = newClient().createDataset("d");
+  ds.addRecord("a");
+  await ds.push();
+  ds.addRecord("b");
+  await ds.push();
+
+  const recordPosts = mock.matching("POST /api/v2/llm-obs/v1/proj-1/datasets/ds-1/records");
+  assert.equal(recordPosts.length, 2);
+  assert.deepEqual(
+    recordPosts[1].body.data.attributes.records.map((r: any) => r.input),
+    ["b"],
+    "second push only sends the newly added record",
+  );
+});
+
+test("DD auth headers are attached to every request", async () => {
+  const ds = newClient().createDataset("d");
+  ds.addRecord("a");
+  await ds.push();
+  for (const req of mock.requests) {
+    assert.equal(req.headers["DD-API-KEY"], "key");
+    assert.equal(req.headers["DD-APPLICATION-KEY"], "app");
+  }
+});
+
+test("pullDataset finds a dataset by name and loads its records", async () => {
+  mock.restore();
+  mock = new MockFetch([
+    { match: "POST /api/v2/llm-obs/v1/projects", response: { data: { id: "proj-1" } } },
+    {
+      match: "GET /api/v2/llm-obs/v1/proj-1/datasets/ds-9/records",
+      response: {
+        // The generated record model carries input/expected_output/metadata at the
+        // top level of each data item (not under `attributes`).
+        data: [
+          { id: "r1", input: "i1", expected_output: "e1", metadata: { a: 1 } },
+          { id: "r2", input: "i2" },
+        ],
+      },
+    },
+    {
+      match: "GET /api/v2/llm-obs/v1/proj-1/datasets",
+      response: {
+        data: [
+          { id: "ds-other", attributes: { name: "nope" } },
+          { id: "ds-9", attributes: { name: "wanted", description: "d" } },
+        ],
+      },
+    },
+  ]);
+  mock.install();
+
+  const ds = await newClient().pullDataset("wanted");
+  assert.equal(ds.id(), "ds-9");
+  assert.equal(ds.projectId(), "proj-1");
+  assert.deepEqual([...ds.recordIds()], ["r1", "r2"]);
+  const recs = ds.records();
+  assert.equal(recs.length, 2);
+  assert.equal(recs[0].input, "i1");
+  assert.deepEqual(recs[0].metadata, { a: 1 });
+});
+
+test("pullDataset throws a clear error when the dataset is absent", async () => {
+  mock.restore();
+  mock = new MockFetch([
+    { match: "POST /api/v2/llm-obs/v1/projects", response: { data: { id: "proj-1" } } },
+    { match: "GET /api/v2/llm-obs/v1/proj-1/datasets", response: { data: [] } },
+  ]);
+  mock.install();
+  await assert.rejects(() => newClient().pullDataset("ghost"), /not found.*after retries/);
+});

--- a/experiments/node-sdk/test/experiment.test.ts
+++ b/experiments/node-sdk/test/experiment.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+import { Experiment, ExperimentsClient } from "../src/index.js";
+import { MockFetch, defaultRoutes } from "./mockFetch.js";
+
+let mock: MockFetch;
+
+function newClient(): ExperimentsClient {
+  return new ExperimentsClient({
+    apiKey: "key",
+    applicationKey: "app",
+    site: "datad0g.com", // staging — must route without special handling (W6/W7)
+    projectName: "p",
+    httpApi: mock.httpLibrary,
+  });
+}
+
+beforeEach(() => {
+  mock = new MockFetch(defaultRoutes());
+  mock.install();
+});
+afterEach(() => mock.restore());
+
+function buildExperiment(client: ExperimentsClient) {
+  const ds = client.createDataset("d");
+  ds.addRecord("apple banana", "fruit", { row: 0 });
+  ds.addRecord("car truck", "vehicle", { row: 1 });
+  ds.addRecord("x", "y", { row: 2 });
+  ds.addRecord("z", "w", { row: 3 });
+
+  return Experiment.builder<string, string>(client)
+    .name("topic-relevance")
+    .description("test exp")
+    .dataset(ds)
+    .task((input) => `echo:${input}`)
+    .evaluator("nonempty", (_i, o) => typeof o === "string" && o.length > 0) // boolean
+    .evaluator("length", (_i, o) => String(o).length) // number -> score
+    .evaluator("label", (_i, o) => (String(o).includes("apple") ? "match" : "miss")) // categorical
+    .tags({ env: "test" })
+    .config({ temperature: 0 })
+    .build();
+}
+
+test("run() returns a result with one row per record and a dashboard url", async () => {
+  const client = newClient();
+  const result = await buildExperiment(client).run();
+
+  assert.equal(result.experimentId, "exp-1");
+  assert.equal(result.rows.length, 4);
+  assert.equal(result.url, "https://app.datad0g.com/llm/experiments/exp-1");
+  assert.equal(result.rows[0].output, "echo:apple banana");
+  assert.equal(result.rows[0].isError, false);
+  assert.equal(result.rows[0].evaluations.nonempty, true);
+  assert.equal(result.rows[0].evaluations.length, "echo:apple banana".length);
+  assert.equal(result.rows[0].evaluations.label, "match");
+});
+
+test("experiment create body carries project_id, dataset_id, config and ensure_unique", async () => {
+  await buildExperiment(newClient()).run();
+  const createReq = mock
+    .matching("POST /api/v2/llm-obs/v1/experiments")
+    .filter((r) => !r.path.includes("/events"))[0];
+  assert.ok(createReq);
+  const attrs = createReq.body.data.attributes;
+  assert.equal(createReq.body.data.type, "experiments");
+  assert.equal(attrs.name, "topic-relevance");
+  assert.equal(attrs.project_id, "proj-1");
+  assert.equal(attrs.dataset_id, "ds-1");
+  assert.equal(attrs.ensure_unique, true);
+  assert.deepEqual(attrs.config, { temperature: 0 });
+});
+
+test("events POST uses type 'experiments' (W2) with spans and metrics", async () => {
+  await buildExperiment(newClient()).run();
+  const eventsReq = mock.matching("POST /api/v2/llm-obs/v1/experiments/exp-1/events")[0];
+  assert.ok(eventsReq);
+  assert.equal(eventsReq.body.data.type, "experiments");
+  const { spans, metrics } = eventsReq.body.data.attributes;
+  assert.equal(spans.length, 4);
+  // 4 rows * 3 evaluators
+  assert.equal(metrics.length, 12);
+});
+
+test("span wire format — ids, status, meta and metadata (W4)", async () => {
+  await buildExperiment(newClient()).run();
+  const span = mock.matching("POST /api/v2/llm-obs/v1/experiments/exp-1/events")[0].body.data
+    .attributes.spans[0];
+
+  assert.match(span.span_id, /^[0-9a-f]{32}$/);
+  assert.match(span.trace_id, /^[0-9a-f]{32}$/);
+  assert.equal(span.project_id, "proj-1");
+  assert.equal(span.dataset_id, "ds-1");
+  assert.equal(span.name, "topic-relevance");
+  assert.equal(span.status, "ok");
+  assert.equal(typeof span.start_ns, "number");
+  assert.equal(typeof span.duration, "number");
+  assert.equal(span.meta.input, "apple banana");
+  assert.equal(span.meta.output, "echo:apple banana");
+  assert.equal(span.meta.expected_output, "fruit");
+  // metadata is raw / unwrapped and lives only under meta.metadata
+  assert.deepEqual(span.meta.metadata, { row: 0 });
+});
+
+test("auto tags are present and win over user tags; metadata never appears in tags", async () => {
+  const client = newClient();
+  const ds = client.createDataset("d");
+  ds.addRecord("a", "b", { secret: "should-not-be-a-tag" });
+  const exp = Experiment.builder(client)
+    .name("e")
+    .dataset(ds)
+    .task((i) => i)
+    .evaluator("ok", () => true)
+    .tags({ team: "core", experiment_id: "user-attempt-to-override" })
+    .build();
+  await exp.run();
+
+  const span = mock.matching("POST /api/v2/llm-obs/v1/experiments/exp-1/events")[0].body.data
+    .attributes.spans[0];
+  const tags: string[] = span.tags;
+  assert.ok(tags.includes("experiment_id:exp-1"), "auto experiment_id wins");
+  assert.ok(!tags.includes("experiment_id:user-attempt-to-override"));
+  assert.ok(tags.includes("dataset_id:ds-1"));
+  assert.ok(tags.some((t) => t.startsWith("dataset_record_id:")));
+  assert.ok(tags.includes("team:core"));
+  assert.ok(!tags.some((t) => t.includes("secret")), "metadata is not emitted as a tag");
+});
+
+test("metric typing: boolean -> boolean_value, number -> score_value, other -> categorical_value", async () => {
+  await buildExperiment(newClient()).run();
+  const metrics: any[] = mock.matching("POST /api/v2/llm-obs/v1/experiments/exp-1/events")[0].body
+    .data.attributes.metrics;
+
+  const byLabel = (label: string) => metrics.find((m) => m.label === label && m.span_id);
+  const nonempty = byLabel("nonempty");
+  const length = byLabel("length");
+  const label = byLabel("label");
+
+  assert.equal(nonempty.metric_type, "boolean");
+  assert.equal(nonempty.boolean_value, true);
+  assert.equal(length.metric_type, "score");
+  assert.equal(typeof length.score_value, "number");
+  assert.equal(label.metric_type, "categorical");
+  assert.equal(label.categorical_value, "match");
+
+  // every metric carries the experiment_id auto tag
+  for (const m of metrics) {
+    assert.ok((m.tags as string[]).includes("experiment_id:exp-1"));
+  }
+});
+
+test("status lifecycle: completed on success", async () => {
+  await buildExperiment(newClient()).run();
+  const patch = mock.matching("PATCH /api/v2/llm-obs/v1/experiments/exp-1")[0];
+  assert.ok(patch);
+  assert.equal(patch.body.data.type, "experiments");
+  assert.equal(patch.body.data.attributes.status, "completed");
+});
+
+test("a task exception is captured per-row without aborting the experiment", async () => {
+  const client = newClient();
+  const ds = client.createDataset("d");
+  ds.addRecord("good");
+  ds.addRecord("bad");
+  ds.addRecord("good2");
+
+  const exp = Experiment.builder<string, string>(client)
+    .name("e")
+    .dataset(ds)
+    .task((input) => {
+      if (input === "bad") throw new Error("boom");
+      return `ok:${input}`;
+    })
+    .evaluator("len", (_i, o) => String(o ?? "").length)
+    .build();
+
+  const result = await exp.run();
+  assert.equal(result.rows.length, 3, "all rows present despite the failure");
+  assert.equal(result.rows[1].isError, true);
+  assert.equal(result.rows[1].errorMessage, "boom");
+
+  const spans: any[] = mock.matching("POST /api/v2/llm-obs/v1/experiments/exp-1/events")[0].body
+    .data.attributes.spans;
+  assert.equal(spans[1].status, "error");
+  assert.equal(spans[1].meta.error.message, "boom");
+  // experiment still completes
+  const patch = mock.matching("PATCH /api/v2/llm-obs/v1/experiments/exp-1")[0];
+  assert.equal(patch.body.data.attributes.status, "completed");
+});
+
+test("an evaluator exception is captured per-evaluation without aborting", async () => {
+  const client = newClient();
+  const ds = client.createDataset("d");
+  ds.addRecord("a");
+
+  const exp = Experiment.builder(client)
+    .name("e")
+    .dataset(ds)
+    .task((i) => i)
+    .evaluator("explodes", () => {
+      throw new Error("eval-fail");
+    })
+    .evaluator("fine", () => true)
+    .build();
+
+  const result = await exp.run();
+  assert.equal(result.rows[0].evaluationErrors.explodes, "eval-fail");
+  assert.equal(result.rows[0].evaluations.fine, true);
+
+  const metrics: any[] = mock.matching("POST /api/v2/llm-obs/v1/experiments/exp-1/events")[0].body
+    .data.attributes.metrics;
+  const errored = metrics.find((m) => m.label === "explodes");
+  assert.equal(errored.error.message, "eval-fail");
+});
+
+test("async tasks and evaluators are awaited", async () => {
+  const client = newClient();
+  const ds = client.createDataset("d");
+  ds.addRecord("a");
+  const exp = Experiment.builder<string, string>(client)
+    .name("e")
+    .dataset(ds)
+    .task(async (i) => {
+      await Promise.resolve();
+      return `async:${i}`;
+    })
+    .evaluator("ok", async (_i, o) => String(o).startsWith("async"))
+    .build();
+  const result = await exp.run();
+  assert.equal(result.rows[0].output, "async:a");
+  assert.equal(result.rows[0].evaluations.ok, true);
+});
+
+test("builder requires name, dataset and task", () => {
+  const client = newClient();
+  const ds = client.createDataset("d");
+  assert.throws(() => Experiment.builder(client).dataset(ds).task((i) => i).build(), /name/);
+  assert.throws(() => Experiment.builder(client).name("n").task((i) => i).build(), /dataset/);
+  assert.throws(() => Experiment.builder(client).name("n").dataset(ds).build(), /task/);
+});

--- a/experiments/node-sdk/test/mockFetch.ts
+++ b/experiments/node-sdk/test/mockFetch.ts
@@ -1,0 +1,171 @@
+import { client } from "@datadog/datadog-api-client";
+
+/**
+ * Test transport that serves BOTH paths the SDK uses:
+ *
+ *  1. The generated `datadog-api-client` (project/dataset/experiment creation and
+ *     lists) — intercepted by injecting `mock.httpLibrary` as the client's
+ *     `HttpLibrary`. The generated client uses `cross-fetch`/`node-fetch`, not
+ *     global `fetch`, so overriding `globalThis.fetch` alone would miss it.
+ *  2. The hand-rolled `fetch` calls (records POST → W1, events POST → W2, status
+ *     PATCH) — intercepted by overriding `globalThis.fetch`.
+ *
+ * Both transports consult the same route table and append to the same
+ * `requests` log, so a test can assert on the full wire traffic regardless of
+ * which transport produced it.
+ */
+
+export interface RecordedRequest {
+  method: string;
+  url: string;
+  path: string;
+  headers: Record<string, string>;
+  body: any;
+  /** Which transport produced this request. */
+  via: "fetch" | "generated";
+}
+
+export interface MockRoute {
+  /** e.g. "POST /api/v2/llm-obs/v1/projects" — matched as a prefix on the path. */
+  match: string;
+  status?: number;
+  /** JSON body to return, or a function of the request. */
+  response: unknown | ((req: RecordedRequest) => unknown);
+}
+
+export class MockFetch {
+  readonly requests: RecordedRequest[] = [];
+  private routes: MockRoute[];
+  private original: typeof globalThis.fetch | undefined;
+
+  constructor(routes: MockRoute[]) {
+    this.routes = routes;
+  }
+
+  install(): void {
+    this.original = globalThis.fetch;
+    globalThis.fetch = this.fetchHandler as unknown as typeof globalThis.fetch;
+  }
+
+  restore(): void {
+    if (this.original) globalThis.fetch = this.original;
+  }
+
+  /** Requests filtered to a method + path-prefix. */
+  matching(prefix: string): RecordedRequest[] {
+    const [method, p] = prefix.split(" ");
+    return this.requests.filter((r) => r.method === method && r.path.startsWith(p));
+  }
+
+  /** Resolve a route + payload for a recorded request. */
+  private resolve(req: RecordedRequest): { status: number; payload: unknown } {
+    const route = this.routes.find((r) => {
+      const [m, p] = r.match.split(" ");
+      return m === req.method && req.path.startsWith(p);
+    });
+    if (!route) {
+      return { status: 404, payload: { error: `no mock route for ${req.method} ${req.path}` } };
+    }
+    const payload =
+      typeof route.response === "function"
+        ? (route.response as (req: RecordedRequest) => unknown)(req)
+        : route.response;
+    return { status: route.status ?? 200, payload };
+  }
+
+  // ---- transport 1: global fetch (hand-rolled calls) ----
+  private fetchHandler = async (input: string, init?: RequestInit): Promise<Response> => {
+    const url = String(input);
+    const req: RecordedRequest = {
+      method: (init?.method ?? "GET").toUpperCase(),
+      url,
+      path: new URL(url).pathname,
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+      via: "fetch",
+    };
+    this.requests.push(req);
+    const { status, payload } = this.resolve(req);
+    return new Response(JSON.stringify(payload), { status });
+  };
+
+  // ---- transport 2: generated client HttpLibrary ----
+  get httpLibrary(): client.HttpLibrary {
+    return {
+      send: async (request: client.RequestContext): Promise<client.ResponseContext> => {
+        const url = request.getUrl();
+        const bodyStr = request.getBody();
+        const req: RecordedRequest = {
+          method: String(request.getHttpMethod()).toUpperCase(),
+          url,
+          path: new URL(url).pathname,
+          headers: request.getHeaders(),
+          body: typeof bodyStr === "string" && bodyStr ? JSON.parse(bodyStr) : undefined,
+          via: "generated",
+        };
+        this.requests.push(req);
+        const { status, payload } = this.resolve(req);
+        const json = JSON.stringify(payload);
+        const responseBody: client.ResponseBody = {
+          text: async () => json,
+          binary: async () => Buffer.from(json),
+        };
+        return new client.ResponseContext(status, {}, responseBody);
+      },
+    };
+  }
+}
+
+/** Default happy-path routes for the full experiment flow. */
+export function defaultRoutes(opts?: {
+  projectId?: string;
+  datasetId?: string;
+  experimentId?: string;
+  recordIds?: string[];
+}): MockRoute[] {
+  const projectId = opts?.projectId ?? "proj-1";
+  const datasetId = opts?.datasetId ?? "ds-1";
+  const experimentId = opts?.experimentId ?? "exp-1";
+  const recordIds = opts?.recordIds ?? ["rec-0", "rec-1", "rec-2", "rec-3"];
+
+  // NOTE: routes are matched in order by (method, path-prefix); more specific
+  // prefixes must come first. Generated-client responses are deserialized by the
+  // api-client, so they carry type + attributes (not just id).
+  return [
+    {
+      match: "POST /api/v2/llm-obs/v1/projects",
+      response: { data: { id: projectId, type: "projects", attributes: { name: "p" } } },
+    },
+    {
+      // dataset records POST (hand-rolled, W1). Echo one id per record sent.
+      match: `POST /api/v2/llm-obs/v1/${projectId}/datasets/${datasetId}/records`,
+      response: (req) => {
+        const sent: unknown[] = req.body?.data?.attributes?.records ?? [];
+        return { data: sent.map((_, i) => ({ id: recordIds[i] ?? `rec-${i}` })) };
+      },
+    },
+    {
+      match: `POST /api/v2/llm-obs/v1/${projectId}/datasets`,
+      response: {
+        data: { id: datasetId, type: "datasets", attributes: { name: "d", description: "" } },
+      },
+    },
+    {
+      // experiment events POST (hand-rolled, W2; path ends in /events)
+      match: "POST /api/v2/llm-obs/v1/experiments/",
+      response: { data: { id: experimentId } },
+    },
+    {
+      // experiment create POST (generated; exact, no trailing slash)
+      match: "POST /api/v2/llm-obs/v1/experiments",
+      response: {
+        data: { id: experimentId, type: "experiments", attributes: { name: "e" } },
+      },
+    },
+    {
+      // experiment status PATCH (hand-rolled)
+      match: "PATCH /api/v2/llm-obs/v1/experiments/",
+      response: { data: { id: experimentId } },
+    },
+  ];
+}

--- a/experiments/node-sdk/test/parity.test.ts
+++ b/experiments/node-sdk/test/parity.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+import { buildTopicRelevance } from "../examples/topicRelevance.js";
+import { ExperimentsClient } from "../src/index.js";
+import { MockFetch, defaultRoutes } from "./mockFetch.js";
+
+/**
+ * Artifact-parity check: runs the *actual* TopicRelevance example code against a
+ * capturing mock transport and asserts the wire artifacts it emits (dataset
+ * records, experiment, spans, metrics) match what the Java `runTopicRelevance`
+ * example produces.
+ *
+ * Only the inherently per-run fields differ between any two runs (of either SDK)
+ * and are therefore excluded from the comparison: span_id / trace_id (random),
+ * start_ns / duration (timing), and the server-assigned experiment/dataset/record
+ * ids. Everything an end user sees as "the experiment" — records, inputs,
+ * outputs, expected outputs, metadata, tags, eval labels/types/values — is
+ * deterministic and asserted exactly.
+ */
+
+let mock: MockFetch;
+beforeEach(() => {
+  mock = new MockFetch(defaultRoutes());
+  mock.install();
+});
+afterEach(() => mock.restore());
+
+test("TopicRelevance emits the same artifacts as the Java example", async () => {
+  const client = new ExperimentsClient({
+    apiKey: "k",
+    applicationKey: "a",
+    site: "datadoghq.com",
+    projectName: "node-sdk-bootstrap",
+    httpApi: mock.httpLibrary,
+  });
+
+  // Fixed dataset name so the run is deterministic (the example normally appends
+  // Date.now(), exactly like the Java example).
+  const { dataset, experiment } = buildTopicRelevance(client, "topic-relevance-demo");
+  const result = await experiment.run();
+
+  // ---- 1. Dataset records artifact (what lands in the project's dataset) ----
+  const recordsReq = mock.matching("POST /api/v2/llm-obs/v1/proj-1/datasets/ds-1/records")[0];
+  assert.equal(recordsReq.body.data.type, "datasets"); // W1
+  assert.deepEqual(recordsReq.body.data.attributes.records, [
+    {
+      input: { prompt: "I love hiking in the mountains on weekends.", topics: "outdoor, travel" },
+      expected_output: "true",
+      metadata: { source: "synthetic", difficulty: "easy" },
+    },
+    {
+      input: { prompt: "Explain quantum entanglement in two sentences.", topics: "outdoor, travel" },
+      expected_output: "false",
+      metadata: { source: "synthetic", difficulty: "easy" },
+    },
+    {
+      input: { prompt: "Best Italian restaurants in Brooklyn?", topics: "food, nyc" },
+      expected_output: "true",
+      metadata: { source: "user-report", difficulty: "medium", reviewer: "alex" },
+    },
+    {
+      input: { prompt: "How do I configure nginx for HTTPS?", topics: "food, nyc" },
+      expected_output: "false",
+      metadata: { source: "user-report", difficulty: "hard", reviewer: "alex" },
+    },
+  ]);
+
+  // ---- 2. Experiment artifact ----
+  const expReq = mock
+    .matching("POST /api/v2/llm-obs/v1/experiments")
+    .filter((r) => !r.path.includes("/events"))[0];
+  // The generated client serializes camelCase model props to snake_case on the
+  // wire (ensureUnique → ensure_unique, projectId → project_id) — same as Java's
+  // generated client. The captured body is the actual wire payload.
+  assert.equal(expReq.body.data.type, "experiments");
+  assert.equal(expReq.body.data.attributes.name, "topic-relevance-demo");
+  assert.equal(expReq.body.data.attributes.ensure_unique, true);
+  assert.equal(expReq.body.data.attributes.project_id, "proj-1");
+  assert.equal(expReq.body.data.attributes.dataset_id, "ds-1");
+  assert.deepEqual(expReq.body.data.attributes.config, { approach: "keyword-overlap", version: "v0.1" });
+
+  // ---- 3. Span artifacts (one per row) ----
+  const eventsReq = mock.matching("POST /api/v2/llm-obs/v1/experiments/exp-1/events")[0];
+  assert.equal(eventsReq.body.data.type, "experiments"); // W2
+  const spans: any[] = eventsReq.body.data.attributes.spans;
+  assert.equal(spans.length, 4);
+
+  // The deterministic, user-visible part of each span (volatile ids/timing dropped).
+  const normalizedSpans = spans.map((s) => ({
+    name: s.name,
+    status: s.status,
+    meta: s.meta,
+    // tags minus the volatile dataset_record_id value
+    tags: (s.tags as string[]).filter((t) => !t.startsWith("dataset_record_id:")).sort(),
+  }));
+
+  // All four prompts miss their topic keywords → keywordOverlap=false →
+  // response="false", confidence=0.65 (identical logic to Java).
+  const expectedMeta = (input: any, expected: string, metadata: any) => ({
+    input,
+    output: { response: "false", confidence: 0.65 },
+    expected_output: expected,
+    metadata,
+  });
+  const baseTags = ["dataset_id:ds-1", "experiment_id:exp-1", "owner:design-partner-bootstrap", "variant:java-v0.1"];
+
+  assert.deepEqual(normalizedSpans[0], {
+    name: "topic-relevance-demo",
+    status: "ok",
+    meta: expectedMeta(
+      { prompt: "I love hiking in the mountains on weekends.", topics: "outdoor, travel" },
+      "true",
+      { source: "synthetic", difficulty: "easy" },
+    ),
+    tags: [...baseTags].sort(),
+  });
+  assert.equal(normalizedSpans[2].meta.expected_output, "true");
+  assert.deepEqual(normalizedSpans[2].meta.metadata, { source: "user-report", difficulty: "medium", reviewer: "alex" });
+
+  // ---- 4. Metric artifacts (3 evaluators × 4 rows) ----
+  const metrics: any[] = eventsReq.body.data.attributes.metrics;
+  assert.equal(metrics.length, 12);
+
+  // Group by span so we can check each row's three metrics.
+  const bySpan = new Map<string, Record<string, any>>();
+  for (const m of metrics) {
+    const row = bySpan.get(m.span_id) ?? {};
+    row[m.label] = m;
+    bySpan.set(m.span_id, row);
+  }
+  const rows = [...bySpan.values()];
+  assert.equal(rows.length, 4);
+
+  // exact_match: rows 0 & 2 expected "true" → false; rows 1 & 3 expected "false" → true.
+  const exactMatches = rows.map((r) => r.exact_match.boolean_value);
+  assert.deepEqual(
+    [...exactMatches].sort(),
+    [false, false, true, true],
+    "two exact_match true, two false (deterministic from the heuristic vs labels)",
+  );
+
+  for (const r of rows) {
+    assert.equal(r.exact_match.metric_type, "boolean");
+    assert.equal(r.confidence_score.metric_type, "score");
+    assert.equal(r.confidence_score.score_value, 0.65);
+    assert.equal(r.verdict_category.metric_type, "categorical");
+    assert.equal(r.verdict_category.categorical_value, "off-topic");
+    // every metric carries the experiment_id auto tag
+    assert.ok((r.exact_match.tags as string[]).includes("experiment_id:exp-1"));
+  }
+
+  // ---- 5. Result surface ----
+  assert.equal(result.rows.length, 4);
+  assert.equal(result.url, "https://app.datadoghq.com/llm/experiments/exp-1");
+  assert.equal(dataset.url(), "https://app.datadoghq.com/llm/datasets/ds-1");
+});

--- a/experiments/node-sdk/test/parity.test.ts
+++ b/experiments/node-sdk/test/parity.test.ts
@@ -5,13 +5,11 @@ import { ExperimentsClient } from "../src/index.js";
 import { MockFetch, defaultRoutes } from "./mockFetch.js";
 
 /**
- * Artifact-parity check: runs the *actual* TopicRelevance example code against a
- * capturing mock transport and asserts the wire artifacts it emits (dataset
- * records, experiment, spans, metrics) match what the Java `runTopicRelevance`
- * example produces.
+ * Artifact check: runs the *actual* TopicRelevance example code against a
+ * capturing mock transport and asserts the exact wire artifacts it emits
+ * (dataset records, experiment, spans, metrics).
  *
- * Only the inherently per-run fields differ between any two runs (of either SDK)
- * and are therefore excluded from the comparison: span_id / trace_id (random),
+ * Only the inherently per-run fields are excluded from the comparison: span_id / trace_id (random),
  * start_ns / duration (timing), and the server-assigned experiment/dataset/record
  * ids. Everything an end user sees as "the experiment" — records, inputs,
  * outputs, expected outputs, metadata, tags, eval labels/types/values — is
@@ -25,7 +23,7 @@ beforeEach(() => {
 });
 afterEach(() => mock.restore());
 
-test("TopicRelevance emits the same artifacts as the Java example", async () => {
+test("TopicRelevance emits the expected wire artifacts", async () => {
   const client = new ExperimentsClient({
     apiKey: "k",
     applicationKey: "a",
@@ -35,7 +33,7 @@ test("TopicRelevance emits the same artifacts as the Java example", async () => 
   });
 
   // Fixed dataset name so the run is deterministic (the example normally appends
-  // Date.now(), exactly like the Java example).
+  // Date.now()).
   const { dataset, experiment } = buildTopicRelevance(client, "topic-relevance-demo");
   const result = await experiment.run();
 
@@ -70,8 +68,8 @@ test("TopicRelevance emits the same artifacts as the Java example", async () => 
     .matching("POST /api/v2/llm-obs/v1/experiments")
     .filter((r) => !r.path.includes("/events"))[0];
   // The generated client serializes camelCase model props to snake_case on the
-  // wire (ensureUnique → ensure_unique, projectId → project_id) — same as Java's
-  // generated client. The captured body is the actual wire payload.
+  // wire (ensureUnique → ensure_unique, projectId → project_id). The captured
+  // body is the actual wire payload.
   assert.equal(expReq.body.data.type, "experiments");
   assert.equal(expReq.body.data.attributes.name, "topic-relevance-demo");
   assert.equal(expReq.body.data.attributes.ensure_unique, true);
@@ -95,14 +93,14 @@ test("TopicRelevance emits the same artifacts as the Java example", async () => 
   }));
 
   // All four prompts miss their topic keywords → keywordOverlap=false →
-  // response="false", confidence=0.65 (identical logic to Java).
+  // response="false", confidence=0.65.
   const expectedMeta = (input: any, expected: string, metadata: any) => ({
     input,
     output: { response: "false", confidence: 0.65 },
     expected_output: expected,
     metadata,
   });
-  const baseTags = ["dataset_id:ds-1", "experiment_id:exp-1", "owner:design-partner-bootstrap", "variant:java-v0.1"];
+  const baseTags = ["dataset_id:ds-1", "experiment_id:exp-1", "owner:design-partner-bootstrap", "variant:node-v0.1"];
 
   assert.deepEqual(normalizedSpans[0], {
     name: "topic-relevance-demo",

--- a/experiments/node-sdk/tsconfig.json
+++ b/experiments/node-sdk/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "examples"]
+}


### PR DESCRIPTION
## Summary

Adds **`experiments/node-sdk`**, a Node.js / TypeScript SDK for running Datadog LLM Observability **experiments + datasets** — six small types covering datasets, tasks, evaluators, and experiment runs over the LLM Obs API.

## What's included

- **Six public types**, with idiomatic Node ergonomics (object-arg constructors + a `builder()` alternative, sync-or-async tasks/evaluators, `async run()`):
  `ExperimentsClient`, `Dataset`, `DatasetRecord`, `Task`, `Evaluator`, `Experiment` / `ExperimentResult`.
- **Transport.** Uses the generated `@datadog/datadog-api-client` (`LLMObservabilityApi`, published `^1.58.0` — no build-from-source needed) for project, dataset and experiment creation and for the dataset/record list reads. Three endpoints the generated client cannot perform correctly are hand-rolled over `fetch`:
  - **W1** — records POST must send `type: "datasets"` (generated model emits `"records"`)
  - **W2** — events POST must send `type: "experiments"` (generated model emits `"events"`)
  - **status PATCH** — the generated update model has no `status` field

  The SDK also applies **W5** (relax the generated deserializer's `required`-field enforcement) and **W6/W7** (a fresh `Configuration` with an explicit `baseServer`, so `DD_SITE` is never read eagerly and staging (`datad0g.com`) / GovCloud work).
- **Eventually-consistent reads.** `pullDataset` polls with exponential backoff (30s total ceiling by default) until the dataset is visible; pass `expectedRecordCount` to also wait until every pushed record is readable, so a pull right after a push reflects the full write.
- **Examples** — `topicRelevance`, `minimalExperiment`, `datasetOperations`, runnable via `npm run runTopicRelevance` / `runMinimalExperiment` / `runDatasetOperations`. They write to the `node-sdk-bootstrap` / `node-sdk-minimal` projects.
- **Tests (offline, `node:test`)** — unit + artifact tests assert the exact wire format by injecting a mock `HttpLibrary` into the generated client and overriding `fetch` for the hand-rolled calls. `npm run sanity` is an offline end-to-end smoke check.

## Verification

- `npm test` — 27/27 passing (incl. an artifact test that runs the real `TopicRelevance` example against a capturing transport and asserts the records/spans/metrics it emits)
- `npm run build` — clean (emits `dist/` + `.d.ts`)
- `npm run sanity` — green

## Notes for reviewers

- **Status:** preview (v0.1). Not yet published to npm — intended to be distributed via `npm pack` + GitHub Releases until the API surface stabilizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)