### PR TITLE
fix(experiments): fix experiment rows not showing in UI

### DIFF
--- a/experiments/scripts/simple_boolean_optimization.py
+++ b/experiments/scripts/simple_boolean_optimization.py
@@ -81,7 +81,7 @@ from openai import OpenAI
 from pydantic import BaseModel
 
 # Prevent ddtrace connection refused error
-os.environ["DD_TRACE_ENABLED"] = "false"
+os.environ["DD_APM_TRACING_ENABLED"] = "false"
 
 # Experiment variables
 ML_APP = "YOUR_ML_APP"
@@ -332,7 +332,8 @@ def main():
     """
     LLMObs.enable(
         ml_app=ML_APP,
-        project_name=PROJECT_NAME
+        project_name=PROJECT_NAME,
+        agentless_enabled=True,
     )
 
     # Load dataset

--- a/experiments/scripts/simple_classification_optimization.py
+++ b/experiments/scripts/simple_classification_optimization.py
@@ -89,7 +89,7 @@ from openai import OpenAI
 from pydantic import BaseModel
 
 # Prevent ddtrace connection refused error
-os.environ["DD_TRACE_ENABLED"] = "false"
+os.environ["DD_APM_TRACING_ENABLED"] = "false"
 
 # Experiment variables
 ML_APP = "YOUR_ML_APP"
@@ -318,7 +318,8 @@ def main():
     """
     LLMObs.enable(
         ml_app=ML_APP,
-        project_name=PROJECT_NAME
+        project_name=PROJECT_NAME,
+        agentless_enabled=True,
     )
 
     # Load dataset


### PR DESCRIPTION
## Summary
- Replace `DD_TRACE_ENABLED=false` with `DD_APM_TRACING_ENABLED=false` across all three example scripts — the old env var caused the SDK to use `export_mode=APM_AGENTLESS` (a fallback path) instead of `LLMOBS_AGENTLESS`/`LLMOBS_AGENT_PROXY` (the intended path)
- Add `agentless_enabled=True` to `LLMObs.enable()` — root cause of missing rows: a local Datadog agent with EVP proxy support was intercepting spans and stripping the `_dd.scope="experiments"` field that tells the backend to index spans as experiment rows; bypassing the agent sends spans directly to `llmobs-intake.datadoghq.com` where the scope is preserved
- Fix `simple_llmaaj_optimization.py` (new file): use `evaluators_results` in `accuracy_summary_evaluator` body (was `evaluations`); remove unsupported `method=` parameter from `_prompt_optimization()` call

## Test plan
- [ ] Run any of the three scripts end-to-end against a real dataset — experiment URLs should now show rows in the Datadog Experiments UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)