### PR TITLE
chore: gitignore .venv/, __pycache__/, and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
 myenv/
+.venv/
 .ipynb_checkpoints/
+__pycache__/
+.DS_Store


### PR DESCRIPTION
Adds `.venv/`, `__pycache__/`, and `.DS_Store` to the root `.gitignore` so local virtualenvs, Python bytecode caches, and macOS Finder metadata stop showing up as untracked noise in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)