### PR TITLE
fix(contract-redliner): correct model name

### DIFF
--- a/contract-redliner/contract_redliner/agent.py
+++ b/contract-redliner/contract_redliner/agent.py
@@ -7,7 +7,7 @@ from ddtrace.llmobs.decorators import agent as llmobs_agent
 
 from .policies import POLICY_DB
 
-MODEL = 'gpt-5.4-nano'
+MODEL = 'openai:gpt-5.4-mini'
 
 _TOPIC_KEYWORDS: dict[str, set[str]] = {
     "nda": {"confidential", "disclosure", "proprietary", "secret", "non-disclosure"},

--- a/contract-redliner/experiment.py
+++ b/contract-redliner/experiment.py
@@ -14,7 +14,7 @@ import json
 from pathlib import Path
 from ddtrace.llmobs import LLMObs, EvaluatorResult, LLMJudge, ScoreStructuredOutput
 
-MODEL = 'gpt-5.4-nano'
+MODEL = 'gpt-5.4-mini'
 
 LLMObs.enable(
     ml_app="contract-redliner",


### PR DESCRIPTION
## Summary
- `contract_redliner/agent.py` used the model name `gpt-5.4-nano`, which is missing the `openai:` provider prefix required by Pydantic AI — corrected to `openai:gpt-5.4-mini`
- `experiment.py`'s judge model name updated to match (`gpt-5.4-mini`)

## Test plan
- [x] Follow setup instructions for python virtual env
- [x] Confirm I have OPENAI_API_KEY set already in env var
- [x] Run `dd-auth -- python main.py`
- [x] Confirm auto-instrumented tracing worked as expected
<img width="1911" height="1008" alt="Screenshot 2026-07-02 at 11 59 11 AM" src="https://github.com/user-attachments/assets/547c463c-4c84-49ee-aa64-f5a1c3fe8e0a" />
