### PR TITLE
feat(stock-watchlist-agent): support capture --publish (baseline experiment + cost)

### DIFF
--- a/test-apps/stock-watchlist-agent/TESTING.md
+++ b/test-apps/stock-watchlist-agent/TESTING.md
@@ -1,0 +1,91 @@
+# Testing the `capture --publish` (baseline-with-cost) changes
+
+How to exercise the inline-experiments **capture-publish** flow end to end on this app:
+`capture --publish` publishes the capture as the **baseline experiment** (a real run of the
+boundary, so it carries real spans + token/dollar cost) plus a Dataset; then
+`replay --publish` runs the current code as the **current** experiment over the same dataset
+and links a **compare view**.
+
+Feature branches: ddtrace `feat/llmobs-inline-experiments-capture-publish` (PR #18625) and this
+app's `stock-watchlist-agent-capture-publish`.
+
+## 1. Put both repos on the capture-publish branches
+
+```bash
+git -C ~/dd/dd-trace-py-inline-experiments checkout feat/llmobs-inline-experiments-capture-publish
+cd ~/dd/llm-observability/test-apps/stock-watchlist-agent
+git checkout stock-watchlist-agent-capture-publish
+```
+The app's `.venv` editable-installs `ddtrace` from that worktree, so it picks up the CLI live —
+no reinstall/overlay needed.
+
+## 2. Config via `.env` (no exports — the command auto-loads `.env`)
+
+```bash
+cat > .env <<'ENV'
+OPENAI_API_KEY=sk-...
+DD_API_KEY=...
+DD_SITE=datad0g.com
+DD_LLMOBS_ML_APP=stock-watchlist-agent
+ENV
+echo ".env" >> .gitignore     # never commit secrets
+```
+
+## 3. Sanity check — subject registered
+
+```bash
+PYTHONPATH=. .venv/bin/python -m ddtrace.commands.ddtrace_experiment list src.agents.orchestrator
+# -> portfolio
+```
+
+## 4. Capture → publish the baseline (real run → real cost + dataset)
+
+Single case keeps it cheap; use `capture_watchlists` for the full 8.
+
+```bash
+PYTHONPATH=. .venv/bin/python -m ddtrace.commands.ddtrace_experiment \
+    capture capture_one --publish --project stock-watchlist-agent
+```
+Verify in LLM Obs: the `inline-portfolio-baseline` experiment has **token/dollar cost** (it ran
+the real agent), and the `inline-experiment-portfolio` dataset's records have `expected_output`
+populated.
+
+## 5. Make a change, then replay → publish the current run + compare
+
+```bash
+# edit src/agents/orchestrator.py:  gpt-4o -> gpt-4o-mini
+PYTHONPATH=. .venv/bin/python -m ddtrace.commands.ddtrace_experiment \
+    replay src.agents.orchestrator --publish --project stock-watchlist-agent
+```
+Open the printed **compare** link → baseline vs current over the same dataset, with **cost on
+both** and the eval-metric deltas (completeness / sentiment_consistency / factual_grounding).
+
+## 6. (Optional) offline local loop — no backend
+
+```bash
+PYTHONPATH=. .venv/bin/python -m ddtrace.commands.ddtrace_experiment \
+    capture capture_one:generate_traffic
+
+PYTHONPATH=. .venv/bin/python -m ddtrace.commands.ddtrace_experiment \
+    replay src.agents.orchestrator --evaluate
+```
+
+## What to watch for (backend-coupled — validate on a live run)
+
+1. `capture --publish` baseline shows **real cost** (the agent runs through the engine).
+2. `replay --publish` **reuses the same dataset** via `pull_dataset` — check the capture and
+   replay dataset ids match (it silently falls back to creating one from the local JSON if the
+   pull fails).
+3. `expected_output` **backfill** — the current run's `regression_match` compares against the
+   baseline, not an empty value.
+4. The **compare** link opens the intended baseline-vs-current view.
+
+## Notes
+
+- Without `--publish`, `capture` stays **local** (a `.llmobs_experiments.json` baseline only —
+  no dataset, cost, or compare view).
+- `capture --publish` reads `SUBJECT` and `INPUTS` from the driver module (see
+  `capture_watchlists.py` / `capture_quotes.py` / `capture_one.py`).
+- `capture --publish` supports single-function subjects (both subjects here are).
+- Cost/time knobs: `capture_one` = 1 case; `WATCHLISTS="NVDA"` narrows `capture_watchlists`;
+  `TICKERS="NVDA AAPL"` narrows `capture_quotes`.

--- a/test-apps/stock-watchlist-agent/capture_one.py
+++ b/test-apps/stock-watchlist-agent/capture_one.py
@@ -1,0 +1,29 @@
+"""Single-case capture driver — the smallest end-to-end inline-experiment example.
+
+The experiment boundary is marked in the app source (``@experiment_start`` on
+``analyze_portfolio`` in ``src/agents/orchestrator.py``). This harness exercises it
+**exactly once**, so ``capture`` records a single baseline case — then ``replay --publish``
+turns that one case into a Dataset + Experiment in LLM Observability.
+
+    # 1a. local capture ONE case -> .llmobs_experiments.json (offline; no dataset/cost)
+    ddtrace-experiment capture capture_one:generate_traffic
+
+    # 1b. OR publish the capture as the baseline experiment (real run -> real cost) + dataset
+    ddtrace-experiment capture capture_one --publish --project stock-watchlist-agent
+
+    # 2. replay the current code against it (local, offline): match / changed
+    ddtrace-experiment replay src.agents.orchestrator
+
+    # 3. publish the current run + compare view vs the baseline (needs DD_API_KEY)
+    ddtrace-experiment replay src.agents.orchestrator --publish --project stock-watchlist-agent
+"""
+from src.agents.orchestrator import analyze_portfolio
+
+
+# `--publish` reads these: SUBJECT names the experiment; INPUTS is the single boundary call.
+SUBJECT = "portfolio"
+INPUTS = [{"tickers": ["NVDA"]}]
+
+
+async def generate_traffic():  # local capture: one watchlist -> one (tickers -> briefing) case
+    await analyze_portfolio(["NVDA"])

--- a/test-apps/stock-watchlist-agent/capture_quotes.py
+++ b/test-apps/stock-watchlist-agent/capture_quotes.py
@@ -22,8 +22,17 @@ from src.agents.researcher import stock_quote_lookup
 DEFAULT_TICKERS = ["NVDA", "AAPL", "MSFT", "SPY", "XOM"]
 
 
-async def generate_traffic():
+def _tickers() -> list[str]:
     env = os.environ.get("TICKERS")
-    tickers = env.split() if env else DEFAULT_TICKERS
-    for ticker in tickers:
+    return env.split() if env else DEFAULT_TICKERS
+
+
+# `--publish` reads these: SUBJECT names the experiment; INPUTS are the boundary's kwargs
+# (stock_quote_lookup(ticker=...)), one dataset record each.
+SUBJECT = "stock_quote"
+INPUTS = [{"ticker": t} for t in _tickers()]
+
+
+async def generate_traffic():  # local capture (no --publish): exercise the boundary directly
+    for ticker in _tickers():
         await stock_quote_lookup(ticker)

--- a/test-apps/stock-watchlist-agent/capture_watchlists.py
+++ b/test-apps/stock-watchlist-agent/capture_watchlists.py
@@ -15,6 +15,9 @@ captured case (one ``PortfolioBriefing``).
     # ...with traces sent to LLM Obs, each case linked to its real orchestrator span
     ddtrace-experiment capture capture_watchlists:generate_traffic --trace --ml-app stock-watchlist-agent
 
+    # publish the capture as the baseline experiment (real run -> real cost) + a dataset:
+    ddtrace-experiment capture capture_watchlists --publish --project stock-watchlist-agent
+
     WATCHLISTS="NVDA AMD|AAPL JPM XOM"   # optional override: '|'-separated lists
 """
 import os
@@ -34,8 +37,17 @@ DEFAULT_WATCHLISTS = [
 ]
 
 
-async def generate_traffic():
+def _watchlists() -> list[list[str]]:
     env = os.environ.get("WATCHLISTS")
-    watchlists = [s.split() for s in env.split("|")] if env else DEFAULT_WATCHLISTS
-    for tickers in watchlists:
+    return [s.split() for s in env.split("|")] if env else DEFAULT_WATCHLISTS
+
+
+# `--publish` reads these: SUBJECT names the experiment; INPUTS are the boundary's kwargs
+# (analyze_portfolio(tickers=...)), one dataset record each.
+SUBJECT = "portfolio"
+INPUTS = [{"tickers": w} for w in _watchlists()]
+
+
+async def generate_traffic():  # local capture (no --publish): exercise the boundary directly
+    for tickers in _watchlists():
         await analyze_portfolio(tickers)


### PR DESCRIPTION
## What

Companion demo changes for the ddtrace `capture --publish` feature (DataDog/dd-trace-py#18984, stacked on #18625).

- Capture drivers (`capture_watchlists.py`, `capture_quotes.py`, `capture_one.py`) declare **`SUBJECT`** (the experiment name) and **`INPUTS`** (the boundary's kwargs, one dataset record each), derived from the same watchlists/tickers `generate_traffic()` uses (env overrides honored). `capture --publish` reads these to run the real boundary as the baseline experiment.
- `TESTING.md` — step-by-step guide for the capture-publish flow (baseline w/ cost + dataset → change → replay + compare view).

No change to local `capture` behavior.

## Testing

See `test-apps/stock-watchlist-agent/TESTING.md`. Requires a `ddtrace` build with the capture-publish feature (dd-trace-py#18984). Draft: for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)