### PR TITLE
Add JS stock watchlist agent test app

### DIFF
--- a/test-apps/stock-watchlist-agent-js/.env.example
+++ b/test-apps/stock-watchlist-agent-js/.env.example
@@ -1,0 +1,18 @@
+# OpenAI
+OPENAI_API_KEY=sk-...
+# Optional model overrides
+# OPENAI_MODEL=gpt-4o
+# OPENAI_SEARCH_MODEL=gpt-4o-mini
+# OPENAI_EVAL_MODEL=gpt-4o-mini
+
+# Datadog LLM Observability
+DD_API_KEY=<your-datadog-api-key>
+DD_SITE=datadoghq.com
+DD_LLMOBS_ML_APP=stock-watchlist-agent-js
+DD_LLMOBS_AGENTLESS_ENABLED=true
+DD_ENV=dev
+# Standalone LLMObs mode: do not send regular APM traces to a local Datadog Agent.
+DD_APM_TRACING_ENABLED=false
+
+# Optional service name shown in APM/trace metadata
+DD_SERVICE=stock-watchlist-agent-js

--- a/test-apps/stock-watchlist-agent-js/.gitignore
+++ b/test-apps/stock-watchlist-agent-js/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/test-apps/stock-watchlist-agent-js/README.md
+++ b/test-apps/stock-watchlist-agent-js/README.md
@@ -1,0 +1,115 @@
+# Stock Watchlist Agent JS
+
+JavaScript translation of `test-apps/stock-watchlist-agent`, built with OpenAI's Responses API and instrumented with `dd-trace-js` LLM Observability.
+
+## Architecture
+
+```
+llmobs.trace(kind="agent", name="analyze_portfolio")        ← evals attach here
+└── orchestrator (OpenAI Responses ReAct loop)
+    ├── delegate_research (tool, batched tickers)
+    │   └── stock_researcher (OpenAI Responses ReAct loop)
+    │       ├── get_stock_quote (tool) → OpenAI web search
+    │       ├── search_company_news (tool) → OpenAI web search
+    │       ├── search_public_sentiment (tool) → OpenAI web search
+    │       └── get_company_profile (tool) → OpenAI web search
+    └── delegate_research (tool, second batch — parallel)
+        └── stock_researcher ...
+```
+
+The orchestrator plans how to batch tickers by sector/theme, delegates batches to researcher agents, and synthesizes a portfolio briefing. Each researcher runs a multi-step ReAct loop with four research tools backed by OpenAI web search. Post-run evaluations (completeness, sentiment consistency, factual grounding) are submitted to LLM Observability.
+
+## Development
+
+```bash
+cd test-apps/stock-watchlist-agent-js
+npm install
+cp .env.example .env
+# edit .env with OPENAI_API_KEY and optional Datadog settings
+```
+
+Requires Node.js 20+.
+
+If you see `Error: Cannot find module 'dd-trace'`, `Cannot find module 'openai'`, or `Cannot find module 'dotenv'`, run `npm install` from this directory.
+
+To test a local `dd-trace-js` checkout instead of the published package:
+
+```bash
+npm install /path/to/dd-trace-js/packages/dd-trace
+```
+
+## Running
+
+```bash
+# Either export OPENAI_API_KEY or set it in .env
+npm start -- AAPL GOOGL NVDA
+```
+
+## Running with Datadog LLM Observability
+
+```bash
+# Either export these variables or set them in .env
+export OPENAI_API_KEY="sk-..."
+export DD_API_KEY="<your-datadog-api-key>"
+export DD_SITE="datadoghq.com"  # your Datadog site
+
+npm start -- AAPL GOOGL NVDA
+```
+
+Example `.env`:
+
+```dotenv
+OPENAI_API_KEY=sk-...
+DD_API_KEY=<your-datadog-api-key>
+DD_SITE=datadoghq.com
+DD_LLMOBS_ML_APP=stock-watchlist-agent-js
+DD_LLMOBS_AGENTLESS_ENABLED=true
+```
+
+For Datadog internal/staging credentials, you can populate Datadog keys with:
+
+```bash
+dd-auth --output --domain dd.datad0g.com >> .env
+```
+
+Then confirm `.env` still contains:
+
+```dotenv
+DD_LLMOBS_ML_APP=stock-watchlist-agent-js
+DD_LLMOBS_AGENTLESS_ENABLED=true
+```
+
+Traces appear in **Datadog > LLM Observability** under the `stock-watchlist-agent-js` app.
+
+To override the app name:
+
+```bash
+export DD_LLMOBS_ML_APP="my-custom-name"
+```
+
+The app loads environment variables from `.env` before initializing `dd-trace`, initializes `dd-trace` before loading `openai`, enables `DD_LLMOBS_ENABLED` automatically when `DD_API_KEY` is present, and sets `DD_LLMOBS_AGENTLESS_ENABLED=1` unless you override it. It also sets standalone LLMObs mode (`DD_APM_TRACING_ENABLED=false` by default) so the CLI does not require a local Datadog Agent on `127.0.0.1:8126`.
+
+## Evaluations
+
+When LLMObs is enabled, three evaluations run after each analysis and are submitted to the root `analyze_portfolio` agent span:
+
+| Eval | Type | Description |
+|------|------|-------------|
+| `completeness` | boolean | All requested tickers present in output |
+| `sentiment_consistency` | boolean (LLM judge) | Sentiment labels match analysis narratives |
+| `factual_grounding` | score 1-5 (LLM judge) | Analyses cite specific numbers, dates, events |
+
+## Project Structure
+
+```
+src/
+├── main.js                    # CLI entry point, eval runner
+├── observability.js           # .env loading, dd-trace-js initialization, LLMObs helpers
+├── models.js                  # JSON schemas + runtime validation
+├── evals.js                   # Evaluators + LLMObs submitEvaluation calls
+└── agents/
+    ├── orchestrator.js        # ReAct orchestrator, delegation tool, agent span
+    ├── researcher.js          # Per-batch research agent with 4 tools
+    ├── responses-agent.js     # Generic Responses API function-calling loop
+    └── searcher.js            # OpenAI Responses API web search helper
+```

--- a/test-apps/stock-watchlist-agent-js/package-lock.json
+++ b/test-apps/stock-watchlist-agent-js/package-lock.json
@@ -1,0 +1,1239 @@
+{
+  "name": "stock-watchlist-agent-js",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stock-watchlist-agent-js",
+      "version": "0.1.0",
+      "dependencies": {
+        "dd-trace": "latest",
+        "dotenv": "^16.4.7",
+        "openai": "^4.104.0"
+      },
+      "bin": {
+        "stock-watchlist-agent-js": "src/main.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@datadog/flagging-core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-1.2.1.tgz",
+      "integrity": "sha512-qeDkki9fFlqyoZBrn7tneT6pZ04EKKvf3xxisYw1a74zbJihvQui/ARUsjXCurRpzpFqGGTJw/oz+HnXaKhcdw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "spark-md5": "^3.0.2"
+      }
+    },
+    "node_modules/@datadog/libdatadog": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.4.tgz",
+      "integrity": "sha512-55wHHAuhHOOrBGoWV+fRuEDypN6PMJZq4LTOwExnhoDMvVcZKtqYT05xea/toRs0o75+A1IeNAQHsRLbJMf5oA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/@datadog/native-appsec": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-11.0.1.tgz",
+      "integrity": "sha512-Y/XfknUmmJcw4hhQVhqzgdQvfjy+EGmXuUBgtVkI1r+/qS00egYu+wD/x7pOvjdbZNqN96znVszAnXvDQAzMDQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/native-iast-taint-tracking": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.2.0.tgz",
+      "integrity": "sha512-NpZABJQoNMzF6cU521RT4GQ8/FbfFRoDepOLTcLYKyw0DY2WmSpg3iG+PoQNK4O3jPSXC++K3rg59GiQgA3Mog==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      }
+    },
+    "node_modules/@datadog/native-metrics": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.2.tgz",
+      "integrity": "sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/openfeature-node-server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.0.0.tgz",
+      "integrity": "sha512-Ummu/Bd7ZJpCCNdFnZUt/JI+L1+8OMK53+MyIXbS7dCt4JXWWwelbpzSGqmC2jWbWQ/mTo4hEfnFw3kYOINbXA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@datadog/flagging-core": "1.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@openfeature/server-sdk": ">=1.15.1"
+      }
+    },
+    "node_modules/@datadog/pprof": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.15.1.tgz",
+      "integrity": "sha512-4mI750tX6okNROS4YKvGQjyAQ+VqfzDqzysCytOJhL2E2ktK/q4M0PtC7j70tiirGb/fO9fjma3IMNSRLYX+xQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.8.4",
+        "pprof-format": "^2.2.1",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/pprof/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@datadog/wasm-js-rewriter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz",
+      "integrity": "sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "lru-cache": "^7.14.0",
+        "module-details-from-path": "^1.0.3",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@datadog/wasm-js-rewriter/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.22.0.tgz",
+      "integrity": "sha512-YBrf6SQkn0FNB/dRAtLEs41dvFMUE8CrQTwI+iLaMFUIqWlqGNJfGnulKSneEKS+2OgKTAC6DdmKcZ6tK7kBcg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.11.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
+      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
+      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
+      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
+      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
+      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
+      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
+      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
+      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
+      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
+      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
+      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
+      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
+      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
+      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
+      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
+      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
+      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
+      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
+      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
+      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0",
+      "optional": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.11.tgz",
+      "integrity": "sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/dd-trace": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-6.4.0.tgz",
+      "integrity": "sha512-aRcf+OXejmPmOz5mTg5zkBTAONv+JwHeszdu/sxPEuZvkBYfjHod5XChgSV0rEDwOWvSbe0kaLPdWM/umIftsw==",
+      "license": "(Apache-2.0 OR BSD-3-Clause)",
+      "dependencies": {
+        "dc-polyfill": "^0.1.11",
+        "import-in-the-middle": "^3.3.1",
+        "opentracing": ">=0.14.7"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@datadog/libdatadog": "0.9.4",
+        "@datadog/native-appsec": "11.0.1",
+        "@datadog/native-iast-taint-tracking": "4.2.0",
+        "@datadog/native-metrics": "3.1.2",
+        "@datadog/openfeature-node-server": "2.0.0",
+        "@datadog/pprof": "5.15.1",
+        "@datadog/wasm-js-rewriter": "5.0.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/api-logs": "<1.0.0",
+        "oxc-parser": "^0.132.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
+      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/opentracing": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
+      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
+        "@oxc-parser/binding-android-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-x64": "0.132.0",
+        "@oxc-parser/binding-freebsd-x64": "0.132.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+      }
+    },
+    "node_modules/pprof-format": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
+      "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)",
+      "optional": true
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/test-apps/stock-watchlist-agent-js/package.json
+++ b/test-apps/stock-watchlist-agent-js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "stock-watchlist-agent-js",
+  "version": "0.1.0",
+  "description": "Multi-agent stock watchlist analyst using OpenAI Responses API and dd-trace-js LLM Observability",
+  "main": "src/main.js",
+  "bin": {
+    "stock-watchlist-agent-js": "src/main.js"
+  },
+  "scripts": {
+    "start": "node src/main.js",
+    "analyze": "node src/main.js",
+    "check": "node --check src/main.js && node --check src/observability.js && node --check src/models.js && node --check src/evals.js && node --check src/agents/responses-agent.js && node --check src/agents/searcher.js && node --check src/agents/researcher.js && node --check src/agents/orchestrator.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "dd-trace": "latest",
+    "dotenv": "^16.4.7",
+    "openai": "^4.104.0"
+  }
+}

--- a/test-apps/stock-watchlist-agent-js/src/agents/orchestrator.js
+++ b/test-apps/stock-watchlist-agent-js/src/agents/orchestrator.js
@@ -1,0 +1,138 @@
+'use strict'
+
+const { researchStocks } = require('./researcher')
+const { runResponsesAgent } = require('./responses-agent')
+const { portfolioBriefingSchema, validatePortfolioBriefing } = require('../models')
+const { annotate, exportSpan, traceSpan } = require('../observability')
+
+const delegateResearchTool = {
+  name: 'delegate_research',
+  description: [
+    'Delegate a batch of stock tickers to a specialized research agent.',
+    'The agent conducts multi-step research (price, news, sentiment, fundamentals)',
+    'for every ticker in the batch and returns structured StockAnalysis results.',
+    'Group related stocks together (same sector, similar themes) for focused research.',
+    'You may call this multiple times with different batches — they run in parallel.',
+  ].join(' '),
+  parameters: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      tickers: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Batch of stock ticker symbols to research together',
+      },
+    },
+    required: ['tickers'],
+  },
+  execute: async ({ tickers }) => {
+    const normalized = tickers.map(ticker => String(ticker).toUpperCase())
+    const result = await researchStocks(normalized)
+    return JSON.stringify(result)
+  },
+}
+
+const ORCHESTRATOR_PROMPT = `\
+<scope>
+You are a senior portfolio analyst who plans research strategy, delegates work to \
+specialized research agents, and synthesizes results into a portfolio briefing.
+</scope>
+
+<approach>
+Think step-by-step before taking action:
+1. Review the tickers provided and plan how to batch them efficiently
+2. Group related stocks together (same sector, similar themes) for focused research
+3. Delegate each batch to a research agent via delegate_research
+4. Review the results returned from each batch and identify cross-cutting themes
+5. Synthesize everything into a comprehensive PortfolioBriefing
+</approach>
+
+<tools>
+delegate_research — Delegate a batch of stock tickers to a research agent. \
+The agent conducts multi-step research (price, news, sentiment, fundamentals) \
+for every ticker in the batch. Group related stocks together for efficiency. \
+You may call this multiple times with different batches — they run in parallel.
+</tools>
+
+<examples>
+User: "Analyze AAPL, GOOGL, NVDA, MSFT, TSLA, AMZN"
+
+Thought: 6 tickers across tech. I should batch by similarity:
+- AAPL, MSFT, GOOGL, AMZN: Big tech / cloud platforms
+- NVDA, TSLA: Semiconductors + EVs — smaller batch, different growth drivers
+
+Action: [calls delegate_research(tickers=["AAPL", "MSFT", "GOOGL", "AMZN"])]
+Action: [calls delegate_research(tickers=["NVDA", "TSLA"])]
+
+Result: Research results for both batches returned.
+
+Thought: I now have analyses for all 6 stocks. Key cross-cutting themes:
+- Big tech investing heavily in AI infrastructure
+- Semiconductor demand remains strong driven by AI
+- Mixed sentiment on EV market but Tesla innovating
+
+[Synthesizes into PortfolioBriefing]
+
+---
+
+User: "Analyze AAPL, NVDA"
+
+Thought: Just 2 tickers, both tech but different subsectors. A single batch is most efficient.
+
+Action: [calls delegate_research(tickers=["AAPL", "NVDA"])]
+
+Result: Research for both stocks returned.
+
+Thought: Apple focused on consumer tech, NVIDIA on AI infrastructure. \
+Different growth drivers but both benefit from AI tailwinds. Now I'll synthesize.
+
+[Produces PortfolioBriefing]
+</examples>
+
+<output>
+Be concise and actionable. Cite specific numbers and dates from the research.
+Focus on cross-cutting themes and what matters most to an investor reviewing their watchlist.
+Return JSON only matching the PortfolioBriefing schema. Set generated_at to the current time in the user prompt.
+</output>`
+
+function formatUtcNow () {
+  const date = new Date()
+  const yyyy = date.getUTCFullYear()
+  const mm = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(date.getUTCDate()).padStart(2, '0')
+  const hh = String(date.getUTCHours()).padStart(2, '0')
+  const min = String(date.getUTCMinutes()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd} ${hh}:${min} UTC`
+}
+
+async function analyzePortfolio (tickers) {
+  return traceSpan({ kind: 'agent', name: 'analyze_portfolio' }, async span => {
+    const now = formatUtcNow()
+    const prompt = `Analyze these stock tickers: ${tickers.join(', ')}. Current time: ${now}`
+    const spanContext = exportSpan(span)
+
+    annotate(span, { inputData: tickers, metadata: { generated_at: now } })
+    const briefing = await traceSpan({ kind: 'agent', name: 'orchestrator' }, async orchestratorSpan => {
+      annotate(orchestratorSpan, { inputData: prompt, metadata: { generated_at: now } })
+      const result = await runResponsesAgent({
+        name: 'orchestrator',
+        systemPrompt: ORCHESTRATOR_PROMPT,
+        userPrompt: prompt,
+        outputSchema: portfolioBriefingSchema,
+        outputSchemaName: 'PortfolioBriefing',
+        tools: [delegateResearchTool],
+      })
+      const validated = validatePortfolioBriefing(result)
+      annotate(orchestratorSpan, { outputData: validated })
+      return validated
+    })
+    annotate(span, { outputData: briefing })
+    return { briefing, spanContext }
+  })
+}
+
+module.exports = {
+  analyzePortfolio,
+  ORCHESTRATOR_PROMPT,
+}

--- a/test-apps/stock-watchlist-agent-js/src/agents/researcher.js
+++ b/test-apps/stock-watchlist-agent-js/src/agents/researcher.js
@@ -1,0 +1,137 @@
+'use strict'
+
+const { search } = require('./searcher')
+const { runResponsesAgent } = require('./responses-agent')
+const { researchBatchResultSchema, validateResearchBatchResult } = require('../models')
+const { annotate, traceSpan } = require('../observability')
+
+const stringArg = (name, description) => ({
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    [name]: { type: 'string', description },
+  },
+  required: [name],
+})
+
+const researcherTools = [
+  {
+    name: 'get_stock_quote',
+    description: 'Get the current stock price, daily price change, and key trading data for a ticker symbol.',
+    parameters: stringArg('ticker', 'Stock ticker symbol, e.g. AAPL'),
+    execute: ({ ticker }) => search(`${ticker} stock price today current quote market data`),
+  },
+  {
+    name: 'search_company_news',
+    description: [
+      'Search for recent company news and developments.',
+      "You craft the search query — be specific about what you're looking for",
+      "(e.g. 'NVIDIA Q4 2026 earnings results' or 'Apple AI features Siri delay').",
+    ].join(' '),
+    parameters: stringArg('query', 'Specific company-news search query'),
+    execute: ({ query }) => search(query),
+  },
+  {
+    name: 'search_public_sentiment',
+    description: [
+      'Search for public investor sentiment and discussions about a stock or company.',
+      'Look for Reddit, social media, and forum discussions to gauge retail investor mood.',
+    ].join(' '),
+    parameters: stringArg('query', 'Specific public sentiment search query'),
+    execute: ({ query }) => search(`${query} investor sentiment Reddit discussion forum opinions`),
+  },
+  {
+    name: 'get_company_profile',
+    description: 'Get a company overview including sector, market cap, business description, recent performance, and key financial metrics.',
+    parameters: stringArg('ticker', 'Stock ticker symbol, e.g. NVDA'),
+    execute: ({ ticker }) => search(`${ticker} company profile overview market cap sector fundamentals key metrics 2026`),
+  },
+]
+
+const RESEARCHER_PROMPT = `\
+You are a stock research analyst conducting thorough research on your assigned batch of stocks.
+
+<scope>
+You research stock tickers using available tools, conducting multi-step analysis \
+for each stock in your assigned batch. You must produce a StockAnalysis for every \
+ticker you are assigned.
+</scope>
+
+<approach>
+Think step-by-step before taking action:
+1. Plan your research approach for the assigned tickers
+2. Get price quotes to establish current market positions
+3. Search for recent news with specific, targeted queries — craft them carefully
+4. Check public investor sentiment on Reddit, forums, social media
+5. Get company profiles for fundamental context
+6. After each round, reflect: did something interesting surface? Do you need to dig deeper?
+7. When satisfied, produce a structured StockAnalysis for each ticker
+</approach>
+
+<tools>
+get_stock_quote — Current price and daily change for a ticker.
+search_company_news — Search recent news. You craft the query — be specific.
+search_public_sentiment — Gauge retail investor mood from Reddit/forums.
+get_company_profile — Company overview, sector, market cap, fundamentals.
+</tools>
+
+<examples>
+Assigned: ["AAPL", "NVDA"]
+
+Thought: Two tickers. I'll start by getting current prices for both, then research news for each.
+Action: [calls get_stock_quote("AAPL")]
+Action: [calls get_stock_quote("NVDA")]
+
+Result: AAPL at $262.01 (-1.66%), NVDA at $197.58 (-0.65%)
+
+Thought: Both are slightly down. Let me search for what's driving each.
+Action: [calls search_company_news("Apple Q2 2026 earnings preview iPhone")]
+Action: [calls search_company_news("NVIDIA AI data center revenue 2026")]
+
+Result: Apple earnings coming April 30, NVIDIA reporting record AI revenue.
+
+Thought: Interesting — Apple has earnings soon. Let me check sentiment and get NVIDIA's profile.
+Action: [calls search_public_sentiment("AAPL Apple earnings April 2026")]
+Action: [calls get_company_profile("NVDA")]
+
+Result: [sentiment and profile data]
+
+Thought: I have enough to produce analyses for both stocks.
+[Returns ResearchBatchResult with analyses for AAPL and NVDA]
+</examples>
+
+<output>
+Be specific — cite numbers, dates, and concrete facts. Avoid vague generalities.
+Every StockAnalysis must have all fields populated with real data from your research.
+Return JSON only matching the ResearchBatchResult schema.
+</output>`
+
+async function researchStocks (tickers) {
+  return traceSpan({ kind: 'agent', name: 'stock_researcher' }, async span => {
+    const prompt = [
+      `Research these stocks: ${tickers.join(', ')}.`,
+      'Get current prices, search for recent news and developments,',
+      'check public investor sentiment, and gather company fundamentals.',
+      'Dig deeper if something interesting surfaces.',
+      'Produce a StockAnalysis for each ticker.',
+    ].join(' ')
+
+    annotate(span, { inputData: prompt, metadata: { tickers } })
+    const result = await runResponsesAgent({
+      name: 'stock_researcher',
+      systemPrompt: RESEARCHER_PROMPT,
+      userPrompt: prompt,
+      outputSchema: researchBatchResultSchema,
+      outputSchemaName: 'ResearchBatchResult',
+      tools: researcherTools,
+    })
+    const validated = validateResearchBatchResult(result)
+    annotate(span, { outputData: validated })
+    return validated
+  })
+}
+
+module.exports = {
+  researchStocks,
+  RESEARCHER_PROMPT,
+}

--- a/test-apps/stock-watchlist-agent-js/src/agents/responses-agent.js
+++ b/test-apps/stock-watchlist-agent-js/src/agents/responses-agent.js
@@ -1,0 +1,140 @@
+'use strict'
+
+const { annotate, traceSpan } = require('../observability')
+const OpenAI = require('openai')
+
+const client = new OpenAI()
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4o'
+
+function jsonSchemaFormat (name, schema) {
+  return {
+    type: 'json_schema',
+    name,
+    strict: true,
+    schema,
+  }
+}
+
+function toolDefinition ({ name, description, parameters }) {
+  return {
+    type: 'function',
+    name,
+    description,
+    strict: true,
+    parameters,
+  }
+}
+
+function extractOutputText (response) {
+  if (response.output_text) return response.output_text
+
+  const parts = []
+  for (const item of response.output || []) {
+    if (item.type !== 'message') continue
+    for (const content of item.content || []) {
+      if (content.type === 'output_text' && content.text) {
+        parts.push(content.text)
+      }
+    }
+  }
+  return parts.join('\n')
+}
+
+function parseJsonOutput (text) {
+  const trimmed = text.trim()
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/)
+  return JSON.parse(fenced ? fenced[1] : trimmed)
+}
+
+function stringifyToolOutput (value) {
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}
+
+async function runResponsesAgent ({
+  name,
+  systemPrompt,
+  userPrompt,
+  outputSchema,
+  outputSchemaName,
+  tools,
+  model = DEFAULT_MODEL,
+  maxTurns = 12,
+}) {
+  const toolDefinitions = tools.map(toolDefinition)
+  const toolMap = new Map(tools.map(tool => [tool.name, tool]))
+  const input = [{ role: 'user', content: userPrompt }]
+
+  annotate({
+    inputData: userPrompt,
+    toolDefinitions: toolDefinitions.map(tool => ({
+      name: tool.name,
+      description: tool.description,
+      schema: tool.parameters,
+    })),
+    metadata: { model, agent: name },
+  })
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    const response = await client.responses.create({
+      model,
+      instructions: systemPrompt,
+      input,
+      tools: toolDefinitions,
+      parallel_tool_calls: true,
+      text: {
+        format: jsonSchemaFormat(outputSchemaName || name, outputSchema),
+      },
+    })
+
+    const functionCalls = (response.output || []).filter(item => item.type === 'function_call')
+    if (functionCalls.length === 0) {
+      const outputText = extractOutputText(response)
+      const parsed = parseJsonOutput(outputText)
+      annotate({ outputData: parsed })
+      return parsed
+    }
+
+    input.push(...response.output)
+
+    const toolOutputs = await Promise.all(functionCalls.map(async call => {
+      const tool = toolMap.get(call.name)
+      if (!tool) {
+        return {
+          type: 'function_call_output',
+          call_id: call.call_id,
+          output: `Unknown tool: ${call.name}`,
+        }
+      }
+
+      try {
+        const args = call.arguments ? JSON.parse(call.arguments) : {}
+        const output = await traceSpan({ kind: 'tool', name: call.name }, async span => {
+          annotate(span, { inputData: args, metadata: { agent: name, tool: call.name } })
+          const result = await tool.execute(args)
+          annotate(span, { outputData: result })
+          return result
+        })
+        return {
+          type: 'function_call_output',
+          call_id: call.call_id,
+          output: stringifyToolOutput(output),
+        }
+      } catch (err) {
+        return {
+          type: 'function_call_output',
+          call_id: call.call_id,
+          output: `Tool ${call.name} failed: ${err.message}`,
+        }
+      }
+    }))
+
+    input.push(...toolOutputs)
+  }
+
+  throw new Error(`${name} did not produce final structured output after ${maxTurns} turns`)
+}
+
+module.exports = {
+  runResponsesAgent,
+  jsonSchemaFormat,
+}

--- a/test-apps/stock-watchlist-agent-js/src/agents/searcher.js
+++ b/test-apps/stock-watchlist-agent-js/src/agents/searcher.js
@@ -1,0 +1,26 @@
+'use strict'
+
+require('../observability')
+const OpenAI = require('openai')
+
+const client = new OpenAI()
+
+const SEARCH_INSTRUCTIONS = [
+  'Search the web for the requested information and return a concise, factual summary of your findings.',
+  'Include specific numbers, dates, and sources where possible.',
+  'Do not editorialize.',
+].join(' ')
+
+async function search (query) {
+  const response = await client.responses.create({
+    model: process.env.OPENAI_SEARCH_MODEL || 'gpt-4o-mini',
+    instructions: SEARCH_INSTRUCTIONS,
+    input: query,
+    tools: [{ type: 'web_search' }],
+  })
+  return response.output_text || ''
+}
+
+module.exports = {
+  search,
+}

--- a/test-apps/stock-watchlist-agent-js/src/evals.js
+++ b/test-apps/stock-watchlist-agent-js/src/evals.js
@@ -1,0 +1,158 @@
+'use strict'
+
+require('./observability')
+const OpenAI = require('openai')
+const { jsonSchemaFormat } = require('./agents/responses-agent')
+const { annotate, submitEvaluation, traceSpan } = require('./observability')
+
+const client = new OpenAI()
+
+const booleanJudgeSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    value: { type: 'boolean' },
+    reasoning: { type: 'string' },
+  },
+  required: ['value', 'reasoning'],
+}
+
+const scoreJudgeSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    value: { type: 'number' },
+    reasoning: { type: 'string' },
+  },
+  required: ['value', 'reasoning'],
+}
+
+function parseJsonOutput (response) {
+  const text = response.output_text || ''
+  return JSON.parse(text.trim())
+}
+
+function completenessEvaluation (briefing, requestedTickers) {
+  const resultTickers = new Set((briefing.analyses || []).map(analysis => analysis.ticker.toUpperCase()))
+  const requested = new Set(requestedTickers.map(ticker => ticker.toUpperCase()))
+  const missing = [...requested].filter(ticker => !resultTickers.has(ticker)).sort()
+  const passed = missing.length === 0
+
+  return {
+    value: passed,
+    assessment: passed ? 'pass' : 'fail',
+    reasoning: passed
+      ? 'All requested tickers present in output.'
+      : `Missing tickers: ${missing.join(', ')}`,
+  }
+}
+
+async function runBooleanJudge ({ name, prompt, outputData }) {
+  return traceSpan({ kind: 'task', name }, async span => {
+    annotate(span, { inputData: { output_data: outputData } })
+    const response = await client.responses.create({
+      model: process.env.OPENAI_EVAL_MODEL || 'gpt-4o-mini',
+      input: prompt.replace('{{output_data}}', JSON.stringify(outputData, null, 2)),
+      text: { format: jsonSchemaFormat(name, booleanJudgeSchema) },
+    })
+    const result = parseJsonOutput(response)
+    annotate(span, { outputData: result })
+    return {
+      value: Boolean(result.value),
+      assessment: result.value ? 'pass' : 'fail',
+      reasoning: result.reasoning || '',
+    }
+  })
+}
+
+async function runScoreJudge ({ name, prompt, outputData, minThreshold }) {
+  return traceSpan({ kind: 'task', name }, async span => {
+    annotate(span, { inputData: { output_data: outputData } })
+    const response = await client.responses.create({
+      model: process.env.OPENAI_EVAL_MODEL || 'gpt-4o-mini',
+      input: prompt.replace('{{output_data}}', JSON.stringify(outputData, null, 2)),
+      text: { format: jsonSchemaFormat(name, scoreJudgeSchema) },
+    })
+    const result = parseJsonOutput(response)
+    const value = Math.max(1, Math.min(5, Number(result.value)))
+    annotate(span, { outputData: { value, reasoning: result.reasoning || '' } })
+    return {
+      value,
+      assessment: value >= minThreshold ? 'pass' : 'fail',
+      reasoning: result.reasoning || '',
+    }
+  })
+}
+
+const sentimentPrompt = `\
+Review these stock analyses. For each stock, check whether the sentiment label \
+(bullish/bearish/neutral) is consistent with the summary and key factors.
+
+Rules:
+- 'neutral' is valid when there are mixed positive and negative signals
+- Only flag clear contradictions (e.g., 'bullish' but summary describes major losses)
+- When in doubt, consider it consistent
+
+Return JSON with {"value": boolean, "reasoning": string}.
+
+Analyses:
+{{output_data}}`
+
+const groundingPrompt = `\
+Rate the factual grounding of these stock analyses.
+
+1 = Entirely vague, no specific facts cited
+2 = Mostly vague with occasional specifics
+3 = Mix of vague and specific claims
+4 = Mostly grounded with concrete numbers, dates, and events
+5 = Thoroughly grounded with specific revenue figures, dates, named events throughout
+
+Return JSON with {"value": number, "reasoning": string}.
+
+Analyses:
+{{output_data}}`
+
+async function runEvaluations (briefing, requestedTickers, spanContext) {
+  const outputData = JSON.parse(JSON.stringify(briefing))
+
+  const completeness = completenessEvaluation(briefing, requestedTickers)
+  submitEvaluation(spanContext, {
+    label: 'completeness',
+    metricType: 'boolean',
+    value: completeness.value,
+    assessment: completeness.assessment,
+    reasoning: completeness.reasoning,
+  })
+
+  const sentiment = await runBooleanJudge({
+    name: 'sentiment_consistency',
+    prompt: sentimentPrompt,
+    outputData,
+  })
+  submitEvaluation(spanContext, {
+    label: 'sentiment_consistency',
+    metricType: 'boolean',
+    value: sentiment.value,
+    assessment: sentiment.assessment,
+    reasoning: sentiment.reasoning,
+  })
+
+  const grounding = await runScoreJudge({
+    name: 'factual_grounding',
+    prompt: groundingPrompt,
+    outputData,
+    minThreshold: 3,
+  })
+  submitEvaluation(spanContext, {
+    label: 'factual_grounding',
+    metricType: 'score',
+    value: grounding.value,
+    assessment: grounding.assessment,
+    reasoning: grounding.reasoning,
+  })
+}
+
+module.exports = {
+  completenessEvaluation,
+  runEvaluations,
+}

--- a/test-apps/stock-watchlist-agent-js/src/main.js
+++ b/test-apps/stock-watchlist-agent-js/src/main.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+'use strict'
+
+const { flush, isLLMObsEnabled, mlApp, site, env } = require('./observability')
+const { analyzePortfolio } = require('./agents/orchestrator')
+const { runEvaluations } = require('./evals')
+
+function printBriefing (briefing) {
+  console.log('\n' + '='.repeat(60))
+  console.log('  STOCK WATCHLIST BRIEFING')
+  console.log('='.repeat(60))
+  console.log(`\nGenerated: ${briefing.generated_at}`)
+  console.log(`\n${'─'.repeat(60)}`)
+  console.log('MARKET OVERVIEW')
+  console.log('─'.repeat(60))
+  console.log(briefing.market_overview)
+
+  for (const analysis of briefing.analyses) {
+    console.log(`\n${'─'.repeat(60)}`)
+    console.log(`  ${analysis.ticker} (${analysis.company_name})`)
+    console.log(`  ${analysis.current_price}  (${analysis.price_change})`)
+    console.log(`  Sentiment: ${analysis.sentiment.toUpperCase()}`)
+    console.log('─'.repeat(60))
+    console.log(`\n${analysis.summary}\n`)
+    console.log('Key Factors:')
+    for (const factor of analysis.key_factors) {
+      console.log(`  * ${factor}`)
+    }
+    console.log('\nRecent News:')
+    for (const news of analysis.recent_news) {
+      console.log(`  - ${news}`)
+    }
+    console.log('\nPublic Sentiment:')
+    console.log(`  ${analysis.public_sentiment_summary}`)
+  }
+
+  console.log(`\n${'─'.repeat(60)}`)
+  console.log('HIGHLIGHTS')
+  console.log('─'.repeat(60))
+  for (const highlight of briefing.highlights) {
+    console.log(`  >> ${highlight}`)
+  }
+
+  console.log('\n' + '='.repeat(60) + '\n')
+}
+
+function parseArgs (argv) {
+  const args = argv.slice(2)
+  if (args.includes('-h') || args.includes('--help')) {
+    console.log('Usage: node src/main.js <TICKER> [TICKER ...]')
+    console.log('Example: node src/main.js AAPL GOOGL NVDA')
+    process.exit(0)
+  }
+  return args.map(ticker => ticker.toUpperCase())
+}
+
+async function main (tickers) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY is required')
+  }
+
+  console.log(`Analyzing ${tickers.length} ticker(s): ${tickers.join(', ')}`)
+  if (isLLMObsEnabled()) {
+    console.log(`LLMObs enabled: ml_app=${mlApp}, site=${site}, env=${env}`)
+  } else {
+    console.log('LLMObs disabled: set DD_API_KEY (or DD_LLMOBS_ENABLED=true) to submit traces')
+  }
+  console.log('Running parallel analysis with web search...\n')
+
+  const { briefing, spanContext } = await analyzePortfolio(tickers)
+  if (isLLMObsEnabled() && spanContext) {
+    console.log(`LLMObs trace context: trace_id=${spanContext.traceId}, span_id=${spanContext.spanId}`)
+  }
+  printBriefing(briefing)
+
+  if (isLLMObsEnabled() && spanContext) {
+    console.log('Running evaluations...')
+    await runEvaluations(briefing, tickers, spanContext)
+    console.log('Evaluations submitted to LLM Observability.\n')
+  }
+}
+
+async function cli () {
+  const tickers = parseArgs(process.argv)
+  if (tickers.length === 0) {
+    console.error('Error: provide at least one ticker symbol')
+    console.error('Usage: node src/main.js <TICKER> [TICKER ...]')
+    process.exitCode = 1
+    return
+  }
+
+  try {
+    await main(tickers)
+  } finally {
+    flush()
+  }
+}
+
+if (require.main === module) {
+  cli().catch(err => {
+    console.error(err.stack || err.message)
+    process.exitCode = 1
+  })
+}
+
+module.exports = {
+  main,
+  printBriefing,
+}

--- a/test-apps/stock-watchlist-agent-js/src/models.js
+++ b/test-apps/stock-watchlist-agent-js/src/models.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const stockAnalysisSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    ticker: { type: 'string' },
+    company_name: { type: 'string' },
+    current_price: { type: 'string' },
+    price_change: { type: 'string' },
+    recent_news: { type: 'array', items: { type: 'string' } },
+    sentiment: { type: 'string', enum: ['bullish', 'bearish', 'neutral'] },
+    public_sentiment_summary: { type: 'string' },
+    key_factors: { type: 'array', items: { type: 'string' } },
+    summary: { type: 'string' },
+  },
+  required: [
+    'ticker',
+    'company_name',
+    'current_price',
+    'price_change',
+    'recent_news',
+    'sentiment',
+    'public_sentiment_summary',
+    'key_factors',
+    'summary',
+  ],
+}
+
+const researchBatchResultSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    analyses: { type: 'array', items: stockAnalysisSchema },
+  },
+  required: ['analyses'],
+}
+
+const portfolioBriefingSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    analyses: { type: 'array', items: stockAnalysisSchema },
+    market_overview: { type: 'string' },
+    highlights: { type: 'array', items: { type: 'string' } },
+    generated_at: { type: 'string' },
+  },
+  required: ['analyses', 'market_overview', 'highlights', 'generated_at'],
+}
+
+function assertString (value, path) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${path} must be a non-empty string`)
+  }
+}
+
+function assertStringArray (value, path) {
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
+    throw new Error(`${path} must be an array of strings`)
+  }
+}
+
+function validateStockAnalysis (analysis, index = 0) {
+  const path = `analyses[${index}]`
+  if (!analysis || typeof analysis !== 'object' || Array.isArray(analysis)) {
+    throw new Error(`${path} must be an object`)
+  }
+  assertString(analysis.ticker, `${path}.ticker`)
+  assertString(analysis.company_name, `${path}.company_name`)
+  assertString(analysis.current_price, `${path}.current_price`)
+  assertString(analysis.price_change, `${path}.price_change`)
+  assertStringArray(analysis.recent_news, `${path}.recent_news`)
+  if (!['bullish', 'bearish', 'neutral'].includes(analysis.sentiment)) {
+    throw new Error(`${path}.sentiment must be bullish, bearish, or neutral`)
+  }
+  assertString(analysis.public_sentiment_summary, `${path}.public_sentiment_summary`)
+  assertStringArray(analysis.key_factors, `${path}.key_factors`)
+  assertString(analysis.summary, `${path}.summary`)
+  return analysis
+}
+
+function validateResearchBatchResult (result) {
+  if (!result || typeof result !== 'object' || !Array.isArray(result.analyses)) {
+    throw new Error('ResearchBatchResult must contain an analyses array')
+  }
+  result.analyses.forEach(validateStockAnalysis)
+  return result
+}
+
+function validatePortfolioBriefing (briefing) {
+  if (!briefing || typeof briefing !== 'object' || !Array.isArray(briefing.analyses)) {
+    throw new Error('PortfolioBriefing must contain an analyses array')
+  }
+  briefing.analyses.forEach(validateStockAnalysis)
+  assertString(briefing.market_overview, 'market_overview')
+  assertStringArray(briefing.highlights, 'highlights')
+  assertString(briefing.generated_at, 'generated_at')
+  return briefing
+}
+
+module.exports = {
+  stockAnalysisSchema,
+  researchBatchResultSchema,
+  portfolioBriefingSchema,
+  validateResearchBatchResult,
+  validatePortfolioBriefing,
+}

--- a/test-apps/stock-watchlist-agent-js/src/observability.js
+++ b/test-apps/stock-watchlist-agent-js/src/observability.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const path = require('node:path')
+const dotenv = require('dotenv')
+
+const appEnvPath = path.resolve(__dirname, '..', '.env')
+const cwdEnvPath = path.resolve(process.cwd(), '.env')
+
+// Prefer the app-local .env so this JS sample does not accidentally inherit the
+// Python sample's DD_LLMOBS_ML_APP when invoked from a different directory.
+dotenv.config({ path: appEnvPath })
+if (cwdEnvPath !== appEnvPath) {
+  dotenv.config({ path: cwdEnvPath })
+}
+
+const mlApp = process.env.DD_LLMOBS_ML_APP || 'stock-watchlist-agent-js'
+const site = process.env.DD_SITE || 'datadoghq.com'
+const env = process.env.DD_ENV || process.env.NODE_ENV || 'dev'
+const explicitEnabled = process.env.DD_LLMOBS_ENABLED
+const llmobsEnabled = explicitEnabled == null ? Boolean(process.env.DD_API_KEY) : explicitEnabled !== 'false'
+
+if (llmobsEnabled) {
+  process.env.DD_LLMOBS_ENABLED ??= 'true'
+  process.env.DD_LLMOBS_ML_APP ??= mlApp
+  process.env.DD_LLMOBS_AGENTLESS_ENABLED ??= 'true'
+}
+
+const tracer = require('dd-trace').init({
+  service: process.env.DD_SERVICE || 'stock-watchlist-agent-js',
+  site,
+  env,
+  // This sample only needs standalone LLMObs agentless intake. Do not try to
+  // send regular APM traces to a local Datadog Agent on 127.0.0.1:8126.
+  apmTracingEnabled: process.env.DD_APM_TRACING_ENABLED === 'true',
+  llmobs: llmobsEnabled
+    ? {
+        mlApp,
+        agentlessEnabled: process.env.DD_LLMOBS_AGENTLESS_ENABLED !== 'false',
+      }
+    : undefined,
+})
+
+const llmobs = tracer.llmobs
+
+function isLLMObsEnabled () {
+  return Boolean(llmobs && llmobs.enabled)
+}
+
+function traceSpan (options, fn) {
+  if (!isLLMObsEnabled()) {
+    return fn(null)
+  }
+  return llmobs.trace(options, fn)
+}
+
+function annotate (spanOrOptions, maybeOptions) {
+  if (!isLLMObsEnabled()) return
+  try {
+    if (maybeOptions === undefined) {
+      llmobs.annotate(spanOrOptions)
+    } else {
+      llmobs.annotate(spanOrOptions, maybeOptions)
+    }
+  } catch (err) {
+    // Annotation should never make the sample app fail. Keep the application path
+    // equivalent to the Python version's best-effort span-context export.
+    console.warn(`LLMObs annotation failed: ${err.message}`)
+  }
+}
+
+function exportSpan (span) {
+  if (!isLLMObsEnabled() || !span) return null
+  try {
+    return llmobs.exportSpan(span)
+  } catch (err) {
+    console.warn(`LLMObs span export failed: ${err.message}`)
+    return null
+  }
+}
+
+function submitEvaluation (spanContext, options) {
+  if (!isLLMObsEnabled() || !spanContext) return
+  llmobs.submitEvaluation(spanContext, options)
+}
+
+function flush () {
+  if (isLLMObsEnabled()) {
+    llmobs.flush()
+  }
+}
+
+module.exports = {
+  tracer,
+  llmobs,
+  mlApp,
+  site,
+  env,
+  llmobsEnabled,
+  isLLMObsEnabled,
+  traceSpan,
+  annotate,
+  exportSpan,
+  submitEvaluation,
+  flush,
+}


### PR DESCRIPTION
## Summary
- Add a JavaScript version of the stock watchlist agent under `test-apps/stock-watchlist-agent-js`
- Instrument the app with `dd-trace-js` LLM Observability spans and evaluation submission
- Add a README with setup, .env configuration, and run instructions

## Examples
- [Traces in staging](https://ddstaging.datadoghq.com/llm/traces?query=%40ml_app%3Astock-watchlist-agent-js%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&start=1784661568126&end=1784665168126&paused=false)

## Testing
- `cd test-apps/stock-watchlist-agent-js && npm run check`
- Manual LLMObs smoke test confirmed spans submit under `stock-watchlist-agent-js`