### PR TITLE
docs(experiments): remove local path references

### DIFF
--- a/experiments/nodejs/AGENTS.md
+++ b/experiments/nodejs/AGENTS.md
@@ -8,10 +8,9 @@ Every Node.js experiments SDK feature should have a runnable example in this dir
 
 Use production credentials from `dd-auth` / `dd-auth-env`; never paste or print API/application keys.
 
-Preferred command shape with a centralized env file:
+From this directory, use the preferred command shape with a centralized env file:
 
 ```sh
-cd /Users/mehul.sonowal/dd/llm-observability/experiments/nodejs
 EXPERIMENTS_ENV_FILE=/path/to/experiments.env \
   dd-auth --domain dd.datadoghq.com -- env DD_SITE=datadoghq.com npm run validate:experiments
 ```

--- a/experiments/nodejs/README.md
+++ b/experiments/nodejs/README.md
@@ -6,8 +6,9 @@ Every Node.js experiments SDK feature should have a runnable example in this dir
 
 ## Setup
 
+From this directory:
+
 ```sh
-cd /Users/mehul.sonowal/dd/llm-observability/experiments/nodejs
 cp .env.example .env
 # Fill in DD_API_KEY, DD_APP_KEY, and OPENAI_API_KEY.
 # DD_APPLICATION_KEY also works if DD_APP_KEY is not set.


### PR DESCRIPTION
## Summary
- remove the hardcoded local filesystem path from the Node.js experiments documentation
- clarify that setup commands should be run from the example directory

## Validation
- verified no hardcoded path remains
- ran git diff --check